### PR TITLE
fix: disable LLVM bitcode generation to fix build on PostgreSQL 18+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ TESTS_DIR = tests
 # Tell PGXS to clean our build directories
 EXTRA_CLEAN = $(BUILD_DIR) $(TEST_BUILD_DIR) install
 
+# Disable LLVM bitcode generation - we use CMake for compilation, not PGXS
+# This fixes build failures on PostgreSQL installations with LLVM JIT support
+with_llvm = no
+
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)


### PR DESCRIPTION
This PR is majorly created using Claude Code (Opus 4.5)