### PR TITLE
fix: make clean now removes extension files from root directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,6 +356,17 @@ jobs:
         run: |
           ls -la pg_ai_query.so || ls -la build/pg_ai_query.so
           echo "Build artifacts verified!"
+      - name: Test make clean removes extension file
+        run: |
+          export PATH="/usr/lib/postgresql/${{ matrix.pg_version }}/bin:$PATH"
+          echo "Verifying make clean removes pg_ai_query.so..."
+          test -f pg_ai_query.so || { echo "pg_ai_query.so not found before clean"; exit 1; }
+          make clean
+          if [ -f pg_ai_query.so ]; then
+            echo "ERROR: make clean did not remove pg_ai_query.so"
+            exit 1
+          fi
+          echo "make clean correctly removes extension file!"
 
   security-scan:
     name: Security Scan

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ BUILD_DIR = build
 TEST_BUILD_DIR = build_tests
 TESTS_DIR = tests
 
-# Tell PGXS to clean our build directories
-EXTRA_CLEAN = $(BUILD_DIR) $(TEST_BUILD_DIR) install
+# Tell PGXS to clean our build directories and the copied extension file
+EXTRA_CLEAN = $(BUILD_DIR) $(TEST_BUILD_DIR) install pg_ai_query.so pg_ai_query.dylib
 
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)


### PR DESCRIPTION
 Previously, `MODULES = pg_ai_query` told `PGXS` to manage the .so file (including cleaning it). When we removed `MODULES` to fix the issue #29, `PGXS` no longer knew about the .so file, so `make clean` stopped removing it.
 
 This is a fix for issue mentioned above found by @fvlnl.