### PR TITLE
docs: add PostgreSQL build configuration note for extension compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ You can use any valid OpenAI model name. Here is a comparison of common models:
     - CMake 3.16+
     - C++20 compatible compiler
     - API key from OpenAI, Anthropic, or Google (Gemini)
+    - If building PostgreSQL from source: use `./configure --enable-nls` (required for extension compilation)
 
 2.  **Build and Install**:
     ```bash


### PR DESCRIPTION
## Summary

This PR adds an important prerequisite note to the README about the `--enable-nls` configuration flag when building PostgreSQL from source.

## Changes

- Updated the **Installation > Prerequisites** section in README.md
- Added note: "If building PostgreSQL from source: use `./configure --enable-nls` (required for extension compilation)"

## Motivation

Users building PostgreSQL18 from source may encounter compilation errors when installing extensions if the `--enable-nls` flag is not used. This flag is required to enable native language support, which is necessary for extension compilation.

Adding this note helps prevent common build issues and provides clear guidance for users who are compiling PostgreSQL from source rather than using pre-built packages.


```
In file included from /home/highgo/works/repo/pg_ai_query/third_party/ai-sdk-cpp/examples/test_openai.cpp:1:
/home/highgo/works/repo/pg_ai_query/third_party/ai-sdk-cpp/include/ai/logger.h: In function ‘void ai::logger::install_logger(std::shared_ptr<Logger>)’:
/home/highgo/works/repo/pg_ai_query/third_party/ai-sdk-cpp/include/ai/logger.h:119:22: warning: ‘void std::atomic_store(shared_ptr<_Tp>*, shared_ptr<_Tp>) [with _Tp = ai::logger::Logger]’ is deprecated: use 'std::atomic<std::shared_ptr<T>>' instead [-Wdeprecated-declarations]
  119 |     std::atomic_store(&detail::logger_instance(), std::move(logger));
      |     ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/14/memory:81,
                 from /home/highgo/works/repo/pg_ai_query/third_party/ai-sdk-cpp/include/ai/logger.h:6:
/usr/include/c++/14/bits/shared_ptr_atomic.h:183:5: note: declared here
  183 |     atomic_store(shared_ptr<_Tp>* __p, shared_ptr<_Tp> __r)
      |     ^~~~~~~~~~~~
/home/highgo/works/repo/pg_ai_query/third_party/ai-sdk-cpp/include/ai/logger.h: In function ‘ai::logger::Logger& ai::logger::logger()’:
/home/highgo/works/repo/pg_ai_query/third_party/ai-sdk-cpp/include/ai/logger.h:124:30: warning: ‘std::shared_ptr<_Tp> std::atomic_load(const shared_ptr<_Tp>*) [with _Tp = ai::logger::Logger]’ is deprecated: use 'std::atomic<std::shared_ptr<T>>' instead [-Wdeprecated-declarations]
  124 |   auto ptr = std::atomic_load(&detail::logger_instance());
      |              ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/14/bits/shared_ptr_atomic.h:142:5: note: declared here
  142 |     atomic_load(const shared_ptr<_Tp>* __p)
      |     ^~~~~~~~~~~
In file included from /home/highgo/works/repo/ivorysql/IvorySQL/inst/include/postgresql/server/postgres.h:48,
                 from /home/highgo/works/repo/pg_ai_query/src/pg_ai_query.cpp:2:
/usr/include/libintl.h:39:14: error: expected unqualified-id before ‘const’
   39 | extern char *gettext (const char *__msgid)
      |              ^~~~~~~
/usr/include/libintl.h:39:14: error: expected ‘)’ before ‘const’
/home/highgo/works/repo/ivorysql/IvorySQL/inst/include/postgresql/server/c.h:1161:20: note: to match this ‘(’
 1161 | #define gettext(x) (x)
      |                    ^
/usr/include/libintl.h:44:14: error: expected unqualified-id before ‘const’
   44 | extern char *dgettext (const char *__domainname, const char *__msgid)
      |              ^~~~~~~~
/usr/include/libintl.h:44:14: error: expected ‘)’ before ‘const’
/home/highgo/works/repo/ivorysql/IvorySQL/inst/include/postgresql/server/c.h:1162:23: note: to match this ‘(’
 1162 | #define dgettext(d,x) (x)
      |                       ^
/usr/include/libintl.h:61:14: error: expected unqualified-id before ‘unsigned’
   61 | extern char *ngettext (const char *__msgid1, const char *__msgid2,
      |              ^~~~~~~~
/usr/include/libintl.h:61:14: error: expected ‘)’ before ‘unsigned’
/home/highgo/works/repo/ivorysql/IvorySQL/inst/include/postgresql/server/c.h:1163:26: note: to match this ‘(’
 1163 | #define ngettext(s,p,n) ((n) == 1 ? (s) : (p))
      |                          ^
/usr/include/libintl.h:61:14: error: expected ‘)’ before ‘unsigned’
   61 | extern char *ngettext (const char *__msgid1, const char *__msgid2,
      |              ^~~~~~~~
/home/highgo/works/repo/ivorysql/IvorySQL/inst/include/postgresql/server/c.h:1163:25: note: to match this ‘(’
 1163 | #define ngettext(s,p,n) ((n) == 1 ? (s) : (p))
      |                         ^
/usr/include/libintl.h:67:14: error: expected unqualified-id before ‘unsigned’
   67 | extern char *dngettext (const char *__domainname, const char *__msgid1,
      |              ^~~~~~~~~
/usr/include/libintl.h:67:14: error: expected ‘)’ before ‘unsigned’
/home/highgo/works/repo/ivorysql/IvorySQL/inst/include/postgresql/server/c.h:1164:29: note: to match this ‘(’
 1164 | #define dngettext(d,s,p,n) ((n) == 1 ? (s) : (p))
      |                             ^
/usr/include/libintl.h:67:14: error: expected ‘)’ before ‘unsigned’
   67 | extern char *dngettext (const char *__domainname, const char *__msgid1,
      |              ^~~~~~~~~
/home/highgo/works/repo/ivorysql/IvorySQL/inst/include/postgresql/server/c.h:1164:28: note: to match this ‘(’
 1164 | #define dngettext(d,s,p,n) ((n) == 1 ? (s) : (p))
      |                            ^
make[2]: *** [CMakeFiles/pg_ai_query.dir/build.make:79: CMakeFiles/pg_ai_query.dir/src/pg_ai_query.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:487: CMakeFiles/pg_ai_query.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 74%] Linking CXX executable ../../../../../examples/components/anthropic/anthropic_component_demo
[ 74%] Built target anthropic_component_demo
[ 75%] Linking CXX executable ../../../examples/retry_config_example

```

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [x] Documentation changes verified
- [ ] N/A (documentation only)
