### PR TITLE
docs: add field-level documentation for Configuration and QueryRequest

### DIFF
--- a/src/include/config.hpp
+++ b/src/include/config.hpp
@@ -65,10 +65,10 @@ struct Configuration {
   // General settings
 
   /**
-  * Minimum level for log messages: DEBUG, INFO, WARNING, ERROR
-  * Default: INFO
-  * Optional
-  */
+   * Minimum level for log messages: DEBUG, INFO, WARNING, ERROR
+   * Default: INFO
+   * Optional
+   */
   std::string log_level;
 
   /**
@@ -117,10 +117,10 @@ struct Configuration {
    */
   bool show_warnings;
 
-/**
- * Include suggested visualization type for the query results
- * Default: false
- */
+  /**
+   * Include suggested visualization type for the query results
+   * Default: false
+   */
   bool show_suggested_visualization;
 
   /**

--- a/src/include/query_generator.hpp
+++ b/src/include/query_generator.hpp
@@ -8,7 +8,6 @@
 namespace pg_ai {
 
 struct QueryRequest {
-
   /**
    * The natural language description of the desired query
    * Default: required
@@ -29,38 +28,37 @@ struct QueryRequest {
 };
 
 struct QueryResult {
-
-   /**
+  /**
    * Generated SQL query string produced by the AI.
-   * 
+   *
    * Default: Empty string
    */
   std::string generated_query;
 
-    /**
-   * Human-readable explanation describing how the SQL query works
-   * and how it maps to the original natural language request.
+  /**
+ * Human-readable explanation describing how the SQL query works
+ * and how it maps to the original natural language request.
 
-   * Default: Empty string
+ * Default: Empty string
 \
-   */
+ */
   std::string explanation;
 
-    /**
+  /**
    * List of warnings related to the generated query.
    *
    * Default: Empty vector
    */
   std::vector<std::string> warnings;
-   /**
-   * Indicates whether a LIMIT clause was automatically applied
-   * to the generated query.
-   *
-   * Default: false
-  
-   */
+  /**
+  * Indicates whether a LIMIT clause was automatically applied
+  * to the generated query.
+  *
+  * Default: false
+
+  */
   bool row_limit_applied;
-   /**
+  /**
    * Suggested visualization type based on query structure.
    *
    * Possible values:
@@ -72,15 +70,15 @@ struct QueryResult {
    * Default: Empty string
    */
   std::string suggested_visualization;
-   /**
-   * Indicates whether query generation was successful.
-   *
-   * Default: false
+  /**
+  * Indicates whether query generation was successful.
+  *
+  * Default: false
 
-   */
+  */
   bool success;
 
-   /**
+  /**
    * Error message describing the reason for failure.
    *
    * Default: Empty string


### PR DESCRIPTION
Fixes: #43 

While documenting `Configuration` , `QueryRequest` and `QueryResponse` , I referred the available docs:
https://benodiwal.github.io/pg_ai_query/generate-query.html

Most fields are optional because they have default values or fall back to configuration.
I couldn’t find an explicit definition of which fields are considered required vs optional,
so I avoided making assumptions and documented purpose, defaults, and valid values instead.

I'll add whether the field is required or optional once I get your confirmation. @benodiwal 