### PR TITLE
Fix: replacing confusing placeholder for connection

### DIFF
--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -119,10 +119,10 @@ After installation, verify that the extension is properly installed:
 
 ### 1. Connect to PostgreSQL
 
-Connect to your default database (usually `postgres`) or a specific database where you want to install the extension:
+Connect to your database where you want to install the extension:
 
 ```bash
-psql -d postgres
+psql -d <your_database>
 ```
 
 ### 2. Create the Extension


### PR DESCRIPTION
### Description
Updates the **Verification** section in `installation.md` to use the standard `postgres` database instead of the `your_database` placeholder.

### Motivation
New users often copy-paste the "Verification" commands directly to test the installation. The previous command (`psql -d your_database`) caused an immediate fatal error because that database does not exist by default.

By changing this to `psql -d postgres`, the command works out-of-the-box for standard PostgreSQL installations, improving the onboarding experience.

### Related Issue
Fixes #80 

### Type of change
- [x] Documentation change

### Checklist
- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly