### PR TITLE
refactor: replace bare catch(...) with specific exception handling (#49)

### DIFF
--- a/src/core/query_generator.cpp
+++ b/src/core/query_generator.cpp
@@ -186,7 +186,9 @@ std::string QueryGenerator::buildPrompt(const QueryRequest& request) {
         }
       }
     }
-  } catch (...) {
+  } catch (const std::exception& e) {
+    logger::Logger::warning("Error building schema context for prompt: " +
+                            std::string(e.what()));
   }
 
   if (!schema_context.empty()) {


### PR DESCRIPTION
This PR addresses issue #49 by replacing bare `catch(...)` blocks with specific exception handling to prevent swallowing errors and improve debuggability.

##  Key changes
  - In `src/core/query_parser.cpp`:
    - Caught `nlohmann::json::parse_error` specifically for JSON parsing operations.
    - Caught `std::exception` as a fallback for other errors.
    - Added debug/warning logs with the exception message.
  - In `src/core/query_generator.cpp`:
    - Replaced `catch(...)` with `catch(const std::exception&)` in `buildPrompt`.
    - Added warning logs with the exception message.
    
Builds fine, all tests run okay .