### PR TITLE
add input validation for query length

### DIFF
--- a/docs/src/config-reference.md
+++ b/docs/src/config-reference.md
@@ -40,6 +40,7 @@ max_retries = 3
 # Query generation behavior
 enforce_limit = true
 default_limit = 1000
+max_query_length = 4000
 
 [openai]
 # OpenAI provider configuration
@@ -145,6 +146,7 @@ Controls query generation behavior and safety features.
 |--------|------|---------|--------------|-------------|
 | `enforce_limit` | boolean | true | true, false | Always add LIMIT clause to SELECT queries |
 | `default_limit` | integer | 1000 | 1-1000000 | Default row limit when none specified |
+| `max_query_length` | integer | 4000 | 1+ | Maximum characters allowed in natural language query |
 
 #### enforce_limit
 
@@ -172,6 +174,19 @@ Default number of rows to limit when no explicit limit is requested.
 ```ini
 [query]
 default_limit = 2000  # Default to 2000 rows
+```
+
+#### max_query_length
+
+Maximum number of characters allowed in the natural language query. Queries longer than this are rejected before any API call to avoid excessive token usage and API limits.
+
+**Range:** 1 and above (values ≤ 0 are ignored; default is used)
+**Recommended:** 4000 for most use cases
+
+**Example:**
+```ini
+[query]
+max_query_length = 4000  # Reject queries longer than 4000 characters
 ```
 
 ### [openai] Section

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -50,6 +50,9 @@ enforce_limit = true
 # Default LIMIT value when not specified by user
 default_limit = 1000
 
+# Maximum length for natural language queries (characters)
+max_query_length = 4000
+
 [response]
 # Show detailed explanation of what the query does
 show_explanation = true

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -24,6 +24,7 @@ Configuration::Configuration() {
   // Query generation defaults
   enforce_limit = true;
   default_limit = 1000;
+  max_query_length = constants::DEFAULT_MAX_QUERY_LENGTH;
 
   // Response format defaults
   show_explanation = true;
@@ -211,6 +212,11 @@ bool ConfigManager::parseConfig(const std::string& content) {
         config_.enforce_limit = (value == "true");
       else if (key == "default_limit")
         config_.default_limit = std::stoi(value);
+      else if (key == "max_query_length") {
+        int val = std::stoi(value);
+        if (val > 0)
+          config_.max_query_length = val;
+      }
     } else if (current_section == constants::SECTION_RESPONSE) {
       if (key == "show_explanation")
         config_.show_explanation = (value == "true");

--- a/src/core/query_generator.cpp
+++ b/src/core/query_generator.cpp
@@ -8,6 +8,7 @@ extern "C" {
 #include <executor/spi.h>
 }
 
+#include <algorithm>
 #include <cctype>
 #include <optional>
 #include <sstream>
@@ -33,7 +34,11 @@ namespace pg_ai {
 
 QueryResult QueryGenerator::generateQuery(const QueryRequest& request) {
   try {
-    if (request.natural_language.empty()) {
+    const auto& cfg = config::ConfigManager::getConfig();
+
+    // Validate input length before any API call
+    if (request.natural_language.length() >
+        static_cast<size_t>(cfg.max_query_length)) {
       return QueryResult{
           .generated_query = "",
           .explanation = "",
@@ -41,7 +46,25 @@ QueryResult QueryGenerator::generateQuery(const QueryRequest& request) {
           .row_limit_applied = false,
           .suggested_visualization = "",
           .success = false,
-          .error_message = "Natural language query cannot be empty"};
+          .error_message = "Query too long. Maximum " +
+                           std::to_string(cfg.max_query_length) +
+                           " characters allowed. Your query: " +
+                           std::to_string(request.natural_language.length()) +
+                           " characters."};
+    }
+
+    // Validate empty or whitespace-only query
+    if (request.natural_language.empty() ||
+        std::all_of(request.natural_language.begin(),
+                    request.natural_language.end(),
+                    [](unsigned char c) { return std::isspace(c); })) {
+      return QueryResult{.generated_query = "",
+                         .explanation = "",
+                         .warnings = {},
+                         .row_limit_applied = false,
+                         .suggested_visualization = "",
+                         .success = false,
+                         .error_message = "Query cannot be empty."};
     }
 
     // Use ProviderSelector to determine the provider

--- a/src/include/config.hpp
+++ b/src/include/config.hpp
@@ -44,6 +44,7 @@ constexpr int DEFAULT_OPENAI_MAX_TOKENS = 16384;
 constexpr int DEFAULT_ANTHROPIC_MAX_TOKENS = 8192;
 constexpr int DEFAULT_MAX_TOKENS = 4096;
 constexpr double DEFAULT_TEMPERATURE = 0.7;
+constexpr int DEFAULT_MAX_QUERY_LENGTH = 4000;
 }  // namespace constants
 
 /**
@@ -95,6 +96,8 @@ struct Configuration {
   // Query generation settings
   bool enforce_limit;
   int default_limit;
+  /** Maximum characters allowed in natural language query (default: 4000) */
+  int max_query_length;
 
   // Response format settings
   bool show_explanation;

--- a/tests/fixtures/configs/valid_config.ini
+++ b/tests/fixtures/configs/valid_config.ini
@@ -8,6 +8,7 @@ max_retries = 5
 [query]
 enforce_limit = true
 default_limit = 500
+max_query_length = 2000
 
 [response]
 show_explanation = true

--- a/tests/unit/test_config.cpp
+++ b/tests/unit/test_config.cpp
@@ -31,6 +31,7 @@ TEST_F(ConfigManagerTest, LoadsValidCompleteConfig) {
   // Check query settings
   EXPECT_TRUE(config.enforce_limit);
   EXPECT_EQ(config.default_limit, 500);
+  EXPECT_EQ(config.max_query_length, 2000);
 
   // Check response settings
   EXPECT_TRUE(config.show_explanation);
@@ -51,6 +52,7 @@ TEST_F(ConfigManagerTest, LoadsMinimalConfig) {
   EXPECT_FALSE(config.enable_logging);          // default
   EXPECT_EQ(config.request_timeout_ms, 30000);  // default
   EXPECT_EQ(config.max_retries, 3);             // default
+  EXPECT_EQ(config.max_query_length, 4000);     // default
 
   // OpenAI key should be set
   const auto* openai = ConfigManager::getProviderConfig(Provider::OPENAI);
@@ -96,14 +98,11 @@ TEST_F(ConfigManagerTest, LoadsCustomEndpoints) {
   EXPECT_EQ(anthropic->api_endpoint, "https://custom-anthropic.example.com");
 }
 
-// Test loading non-existent file fails 
+// Test loading non-existent file fails
 TEST_F(ConfigManagerTest, ThrowsForNonexistentFile) {
-  EXPECT_THROW(
-      ConfigManager::loadConfig("/nonexistent/path/config.ini"),
-      std::runtime_error
-  );
+  EXPECT_THROW(ConfigManager::loadConfig("/nonexistent/path/config.ini"),
+               std::runtime_error);
 }
-
 
 // Test provider enum to string conversion
 TEST_F(ConfigManagerTest, ProviderToString) {
@@ -240,6 +239,7 @@ max_retries = 10
 
 [query]
 default_limit = 2500
+max_query_length = 8000
 
 [openai]
 api_key = sk-test
@@ -253,6 +253,7 @@ temperature = 0.85
   EXPECT_EQ(config.request_timeout_ms, 120000);
   EXPECT_EQ(config.max_retries, 10);
   EXPECT_EQ(config.default_limit, 2500);
+  EXPECT_EQ(config.max_query_length, 8000);
 
   const auto* openai = ConfigManager::getProviderConfig(Provider::OPENAI);
   ASSERT_NE(openai, nullptr);
@@ -297,6 +298,7 @@ TEST(ConfigurationTest, DefaultConstructorSetsDefaults) {
   EXPECT_EQ(config.max_retries, 3);
   EXPECT_TRUE(config.enforce_limit);
   EXPECT_EQ(config.default_limit, 1000);
+  EXPECT_EQ(config.max_query_length, 4000);
   EXPECT_TRUE(config.show_explanation);
   EXPECT_TRUE(config.show_warnings);
   EXPECT_FALSE(config.show_suggested_visualization);


### PR DESCRIPTION
## Summary
Adds configurable maximum query length and empty/whitespace validation so overly long or empty natural language inputs are rejected before any AI API call.

Fixes #55

## Changes
- **Config:** New `max_query_length` (default 4000) in `Configuration`, parsed from `[query]` in `~/.pg_ai.config`. Invalid/negative values are ignored and the default is used.
- **Validation in `QueryGenerator::generateQuery()`:**  
  - Reject if `natural_language` length &gt; `max_query_length` with an error message that includes the limit and actual length.  
  - Reject empty or whitespace-only input with a clear error message.  
  Validation runs before provider selection and API calls to avoid unnecessary token usage.
- **Docs:** `max_query_length` documented in `configuration.md` and `config-reference.md`.
- **Tests:** Config tests updated for default and parsed `max_query_length`; `valid_config.ini` and `ParsesNumericValues` cover the new setting.

## Acceptance criteria
- [x] Maximum query length is configurable
- [x] Empty queries are rejected with a clear message
- [x] Overly long queries are rejected with character count in the error
- [x] Default limit is 4000 characters
- [x] Validation happens before the API call