### PR TITLE
Add validation for natural language queries with unit tests

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -50,15 +50,19 @@ std::string read_file_or_throw(const std::string& filepath) {
 std::optional<std::string> validate_natural_language_query(
     const std::string& query,
     int max_query_length) {
-  if (query.length() > static_cast<size_t>(max_query_length)) {
-    return "Query too long. Maximum " + std::to_string(max_query_length) +
-           " characters allowed. Your query: " +
-           std::to_string(query.length()) + " characters.";
-  }
+  // Validate content first: ensure query exists before checking properties.
   if (query.empty() ||
       std::all_of(query.begin(), query.end(),
                   [](unsigned char c) { return std::isspace(c); })) {
     return "Query cannot be empty.";
+  }
+  if (max_query_length < 0) {
+    return "Invalid maximum query length.";
+  }
+  if (query.length() > static_cast<size_t>(max_query_length)) {
+    return "Query too long. Maximum " + std::to_string(max_query_length) +
+           " characters allowed. Your query: " +
+           std::to_string(query.length()) + " characters.";
   }
   return std::nullopt;
 }


### PR DESCRIPTION
This PR is a follow-up addressing the minor suggestions from the Claude review on the natural-language query validation PR #92 .

## Summary
Adds input validation for natural language queries used by `generate_query`, with unit tests and small fixes from review.

## Changes
- **Validation** (`src/utils.cpp`): New `validate_natural_language_query()` that:
  - Rejects empty and whitespace-only queries
  - Enforces a configurable max length (default 4000)
  - Rejects negative `max_query_length` to avoid unsigned cast issues
  - Validates “has content” before “length” for clearer error ordering
- **Integration**: Validation is called in `QueryGenerator::generateQuery()` with early return and user-facing error messages.
- **Tests** (`tests/unit/test_utils.cpp`): Unit tests for empty, whitespace-only, too long, valid short, exactly max length, leading/trailing whitespace, and negative max length; brief comments added for maintainability.

## Testing
- Unit tests: `./build/tests/pg_ai_query_tests --gtest_filter="*ValidateNatural*"` (7 tests passing).
- Manual: `SELECT generate_query('');` and `SELECT generate_query('   ');` return the “Query cannot be empty.” error as expected.

```
Note: Google Test filter = *ValidateNatural*
[==========] Running 7 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 7 tests from UtilsTest
[ RUN      ] UtilsTest.ValidateNaturalLanguageQuery_Empty
[       OK ] UtilsTest.ValidateNaturalLanguageQuery_Empty (0 ms)
[ RUN      ] UtilsTest.ValidateNaturalLanguageQuery_WhitespaceOnly
[       OK ] UtilsTest.ValidateNaturalLanguageQuery_WhitespaceOnly (0 ms)
[ RUN      ] UtilsTest.ValidateNaturalLanguageQuery_WithLeadingTrailingWhitespace
[       OK ] UtilsTest.ValidateNaturalLanguageQuery_WithLeadingTrailingWhitespace (0 ms)
[ RUN      ] UtilsTest.ValidateNaturalLanguageQuery_NegativeMaxLength
[       OK ] UtilsTest.ValidateNaturalLanguageQuery_NegativeMaxLength (0 ms)
[ RUN      ] UtilsTest.ValidateNaturalLanguageQuery_TooLong
[       OK ] UtilsTest.ValidateNaturalLanguageQuery_TooLong (0 ms)
[ RUN      ] UtilsTest.ValidateNaturalLanguageQuery_ValidShort
[       OK ] UtilsTest.ValidateNaturalLanguageQuery_ValidShort (0 ms)
[ RUN      ] UtilsTest.ValidateNaturalLanguageQuery_ExactlyMaxLength
[       OK ] UtilsTest.ValidateNaturalLanguageQuery_ExactlyMaxLength (0 ms)
[----------] 7 tests from UtilsTest (0 ms total)

[----------] Global test environment tear-down
[==========] 7 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 7 tests.
```