### PR TITLE
fix: allow system table queries via config and fix get_table_details for schema-qualified names

### DIFF
--- a/docs/src/api-reference.md
+++ b/docs/src/api-reference.md
@@ -204,6 +204,7 @@ max_retries = <integer>
 # Query generation settings
 enforce_limit = true | false
 default_limit = <integer>
+allow_system_tables = true | false
 
 [openai]
 # OpenAI provider settings
@@ -227,6 +228,7 @@ default_model = "claude-sonnet-4-5-20250929"
 | `max_retries` | integer | 0-10 | 3 |
 | `enforce_limit` | boolean | true, false | true |
 | `default_limit` | integer | 1-1000000 | 1000 |
+| `allow_system_tables` | boolean | true, false | false |
 | `api_key` | string | Provider-specific format | "" |
 | `default_model` | string | Provider-specific values | Provider default |
 
@@ -291,7 +293,7 @@ _pg_ai_validate_query(query text) RETURNS boolean;
 The extension performs these security checks:
 
 - **SQL Injection Prevention**: Sanitizes all inputs
-- **System Table Protection**: Blocks access to pg_* and information_schema
+- **System Table Protection**: By default blocks access to pg_catalog and information_schema (configurable via `allow_system_tables`)
 - **DDL Restriction**: Can generate DDL but with warnings
 - **Privilege Respect**: Honors PostgreSQL permission system
 

--- a/docs/src/config-reference.md
+++ b/docs/src/config-reference.md
@@ -147,6 +147,7 @@ Controls query generation behavior and safety features.
 | `enforce_limit` | boolean | true | true, false | Always add LIMIT clause to SELECT queries |
 | `default_limit` | integer | 1000 | 1-1000000 | Default row limit when none specified |
 | `max_query_length` | integer | 4000 | 1+ | Maximum characters allowed in natural language query |
+| `allow_system_tables` | boolean | false | true, false | Allow generated queries to use information_schema / pg_catalog (e.g. for schema introspection) |
 
 #### enforce_limit
 
@@ -187,6 +188,20 @@ Maximum number of characters allowed in the natural language query. Queries long
 ```ini
 [query]
 max_query_length = 4000  # Reject queries longer than 4000 characters
+```
+
+#### allow_system_tables
+
+When enabled, the AI may generate queries that use `information_schema` or `pg_catalog` (e.g. to show table or column structure). By default these are forbidden so that generated queries only target user data.
+
+**Values:**
+- `false`: Do not allow system table access (default)
+- `true`: Allow system table access for schema introspection
+
+**Example:**
+```ini
+[query]
+allow_system_tables = true  # Allow "show me the schema of table X" style queries
 ```
 
 ### [openai] Section

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -117,6 +117,7 @@ Controls query generation behavior.
 |--------|------|---------|-------------|
 | `enforce_limit` | boolean | true | Always add LIMIT clause to SELECT queries |
 | `default_limit` | integer | 1000 | Default row limit when none specified |
+| `allow_system_tables` | boolean | false | Allow generated queries to use information_schema / pg_catalog for schema introspection |
 
 ### [response] Section
 

--- a/sql/pg_ai_query--1.0.sql
+++ b/sql/pg_ai_query--1.0.sql
@@ -47,6 +47,7 @@ LANGUAGE C;
 -- Example usage:
 -- SELECT get_database_tables();
 -- SELECT get_table_details('users');
+-- SELECT get_table_details('sample2.accounts');  -- schema-qualified: schema.table
 -- SELECT get_table_details('orders', 'public');
 
 COMMENT ON FUNCTION get_database_tables() IS
@@ -57,10 +58,10 @@ Example: SELECT get_database_tables();';
 COMMENT ON FUNCTION get_table_details(text, text) IS
 'Returns detailed JSON information about a specific table including columns with their data types, constraints, foreign keys, and indexes.
 Parameters:
-- table_name: Name of the table to inspect
-- schema_name: Schema containing the table (default: public)
+- table_name: Name of the table, or schema-qualified name (e.g. sample2.accounts) when schema_name is omitted
+- schema_name: Schema containing the table (default: public). Omit to use schema.table form in table_name.
 Returns: JSON object with complete table schema information
-Example: SELECT get_table_details(''orders'', ''public'');';
+Example: SELECT get_table_details(''orders'', ''public''); SELECT get_table_details(''sample2.accounts'');';
 
 -- Explain query function: Runs EXPLAIN ANALYZE and provides AI-generated explanation
 CREATE OR REPLACE FUNCTION explain_query(

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -26,6 +26,7 @@ Configuration::Configuration() {
   enforce_limit = true;
   default_limit = 1000;
   max_query_length = constants::DEFAULT_MAX_QUERY_LENGTH;
+  allow_system_tables = false;
 
   // Response format defaults
   show_explanation = true;
@@ -217,7 +218,8 @@ bool ConfigManager::parseConfig(const std::string& content) {
         int val = std::stoi(value);
         if (val > 0)
           config_.max_query_length = val;
-      }
+      } else if (key == "allow_system_tables")
+        config_.allow_system_tables = (value == "true");
     } else if (current_section == constants::SECTION_RESPONSE) {
       if (key == "show_explanation")
         config_.show_explanation = (value == "true");

--- a/src/core/query_generator.cpp
+++ b/src/core/query_generator.cpp
@@ -93,7 +93,8 @@ QueryResult QueryGenerator::generateQuery(const QueryRequest& request) {
                                             gemini_result.error_message};
       }
 
-      return QueryParser::parseQueryResponse(gemini_result.text);
+      return QueryParser::parseQueryResponse(gemini_result.text,
+                                            cfg.allow_system_tables);
     }
 
     // Use AIClientFactory for OpenAI and Anthropic
@@ -148,7 +149,7 @@ QueryResult QueryGenerator::generateQuery(const QueryRequest& request) {
                          .error_message = "Empty response from AI service"};
     }
 
-    return QueryParser::parseQueryResponse(result.text);
+    return QueryParser::parseQueryResponse(result.text, cfg.allow_system_tables);
   } catch (const std::exception& e) {
     return QueryResult{.generated_query = "",
                        .explanation = "",
@@ -173,16 +174,20 @@ std::string QueryGenerator::buildPrompt(const QueryRequest& request) {
     if (schema.success) {
       schema_context = formatSchemaForAI(schema);
 
-      std::vector<std::string> mentioned_tables;
+      std::vector<std::pair<std::string, std::string>> mentioned_tables;
       for (const auto& table : schema.tables) {
+        std::string qualified = table.schema_name + "." + table.table_name;
         if (request.natural_language.find(table.table_name) !=
-            std::string::npos) {
-          mentioned_tables.push_back(table.table_name);
+                std::string::npos ||
+            request.natural_language.find(qualified) != std::string::npos) {
+          mentioned_tables.push_back({table.schema_name, table.table_name});
         }
       }
 
       for (size_t i = 0; i < mentioned_tables.size() && i < 3; ++i) {
-        auto table_details = getTableDetails(mentioned_tables[i]);
+        const auto& schema_name = mentioned_tables[i].first;
+        const auto& table_name = mentioned_tables[i].second;
+        auto table_details = getTableDetails(table_name, schema_name);
         if (table_details.success) {
           schema_context += "\n" + formatTableDetailsForAI(table_details);
         }
@@ -474,7 +479,12 @@ std::string QueryGenerator::formatSchemaForAI(const DatabaseSchema& schema) {
 
   result << "\nCRITICAL: If user asks for tables not listed above, return an "
             "error with available table names.\n";
-  result << "Do NOT query information_schema or pg_catalog tables.\n";
+  if (config::ConfigManager::getConfig().allow_system_tables) {
+    result << "You may query information_schema or pg_catalog when needed for "
+              "schema introspection (e.g. to show table or column structure).\n";
+  } else {
+    result << "Do NOT query information_schema or pg_catalog tables.\n";
+  }
   return result.str();
 }
 

--- a/src/core/query_generator.cpp
+++ b/src/core/query_generator.cpp
@@ -94,7 +94,7 @@ QueryResult QueryGenerator::generateQuery(const QueryRequest& request) {
       }
 
       return QueryParser::parseQueryResponse(gemini_result.text,
-                                            cfg.allow_system_tables);
+                                             cfg.allow_system_tables);
     }
 
     // Use AIClientFactory for OpenAI and Anthropic
@@ -149,7 +149,8 @@ QueryResult QueryGenerator::generateQuery(const QueryRequest& request) {
                          .error_message = "Empty response from AI service"};
     }
 
-    return QueryParser::parseQueryResponse(result.text, cfg.allow_system_tables);
+    return QueryParser::parseQueryResponse(result.text,
+                                           cfg.allow_system_tables);
   } catch (const std::exception& e) {
     return QueryResult{.generated_query = "",
                        .explanation = "",
@@ -480,8 +481,9 @@ std::string QueryGenerator::formatSchemaForAI(const DatabaseSchema& schema) {
   result << "\nCRITICAL: If user asks for tables not listed above, return an "
             "error with available table names.\n";
   if (config::ConfigManager::getConfig().allow_system_tables) {
-    result << "You may query information_schema or pg_catalog when needed for "
-              "schema introspection (e.g. to show table or column structure).\n";
+    result
+        << "You may query information_schema or pg_catalog when needed for "
+           "schema introspection (e.g. to show table or column structure).\n";
   } else {
     result << "Do NOT query information_schema or pg_catalog tables.\n";
   }

--- a/src/core/query_parser.cpp
+++ b/src/core/query_parser.cpp
@@ -138,7 +138,8 @@ bool QueryParser::hasErrorIndicators(const std::string& explanation,
   return false;
 }
 
-QueryResult QueryParser::parseQueryResponse(const std::string& response_text) {
+QueryResult QueryParser::parseQueryResponse(const std::string& response_text,
+                                            bool allow_system_table_access) {
   // Parse SQL, explanation, and metadata from the AI response
   nlohmann::json j = extractSQLFromResponse(response_text);
   std::string sql = j.value("sql", "");
@@ -190,8 +191,8 @@ QueryResult QueryParser::parseQueryResponse(const std::string& response_text) {
                        .error_message = ""};
   }
 
-  // Check for system table access
-  if (accessesSystemTables(sql)) {
+  // Check for system table access (skip when allow_system_table_access is true)
+  if (!allow_system_table_access && accessesSystemTables(sql)) {
     return QueryResult{
         .generated_query = "",
         .explanation = "",

--- a/src/include/config.hpp
+++ b/src/include/config.hpp
@@ -57,6 +57,8 @@ struct Configuration {
   int default_limit;
   /** Maximum characters allowed in natural language query (default: 4000) */
   int max_query_length;
+  /** Allow generated queries to use information_schema / pg_catalog (e.g. for schema introspection). Default: false. */
+  bool allow_system_tables;
 
   // Response format settings
   bool show_explanation;

--- a/src/include/config.hpp
+++ b/src/include/config.hpp
@@ -57,7 +57,8 @@ struct Configuration {
   int default_limit;
   /** Maximum characters allowed in natural language query (default: 4000) */
   int max_query_length;
-  /** Allow generated queries to use information_schema / pg_catalog (e.g. for schema introspection). Default: false. */
+  /** Allow generated queries to use information_schema / pg_catalog (e.g. for
+   * schema introspection). Default: false. */
   bool allow_system_tables;
 
   // Response format settings

--- a/src/include/query_parser.hpp
+++ b/src/include/query_parser.hpp
@@ -35,9 +35,11 @@ class QueryParser {
    * @brief Parse a JSON response into a QueryResult struct
    *
    * @param response_text The raw response text from the LLM
+   * @param allow_system_table_access If true, do not treat information_schema/pg_catalog access as error
    * @return QueryResult with parsed fields and success/error status
    */
-  static QueryResult parseQueryResponse(const std::string& response_text);
+  static QueryResult parseQueryResponse(const std::string& response_text,
+                                        bool allow_system_table_access = false);
 
   /**
    * @brief Check if a SQL query accesses system tables

--- a/src/include/query_parser.hpp
+++ b/src/include/query_parser.hpp
@@ -35,7 +35,8 @@ class QueryParser {
    * @brief Parse a JSON response into a QueryResult struct
    *
    * @param response_text The raw response text from the LLM
-   * @param allow_system_table_access If true, do not treat information_schema/pg_catalog access as error
+   * @param allow_system_table_access If true, do not treat
+   * information_schema/pg_catalog access as error
    * @return QueryResult with parsed fields and success/error status
    */
   static QueryResult parseQueryResponse(const std::string& response_text,

--- a/src/pg_ai_query.cpp
+++ b/src/pg_ai_query.cpp
@@ -124,6 +124,15 @@ Datum get_table_details(PG_FUNCTION_ARGS) {
     std::string schema_name =
         schema_name_arg ? text_to_cstring(schema_name_arg) : "public";
 
+    // If only one argument was passed and it contains a dot, treat as schema.table
+    if (!schema_name_arg) {
+      size_t dot = table_name.find('.');
+      if (dot != std::string::npos && dot > 0 && dot < table_name.size() - 1) {
+        schema_name = table_name.substr(0, dot);
+        table_name = table_name.substr(dot + 1);
+      }
+    }
+
     auto result =
         pg_ai::QueryGenerator::getTableDetails(table_name, schema_name);
 

--- a/src/pg_ai_query.cpp
+++ b/src/pg_ai_query.cpp
@@ -124,7 +124,8 @@ Datum get_table_details(PG_FUNCTION_ARGS) {
     std::string schema_name =
         schema_name_arg ? text_to_cstring(schema_name_arg) : "public";
 
-    // If only one argument was passed and it contains a dot, treat as schema.table
+    // If only one argument was passed and it contains a dot, treat as
+    // schema.table
     if (!schema_name_arg) {
       size_t dot = table_name.find('.');
       if (dot != std::string::npos && dot > 0 && dot < table_name.size() - 1) {

--- a/tests/unit/test_config.cpp
+++ b/tests/unit/test_config.cpp
@@ -271,6 +271,7 @@ enable_logging = true
 
 [query]
 enforce_limit = false
+allow_system_tables = true
 
 [response]
 show_explanation = true
@@ -284,6 +285,7 @@ use_formatted_response = true
   const auto& config = ConfigManager::getConfig();
   EXPECT_TRUE(config.enable_logging);
   EXPECT_FALSE(config.enforce_limit);
+  EXPECT_TRUE(config.allow_system_tables);
   EXPECT_TRUE(config.show_explanation);
   EXPECT_FALSE(config.show_warnings);
   EXPECT_TRUE(config.show_suggested_visualization);
@@ -301,6 +303,7 @@ TEST(ConfigurationTest, DefaultConstructorSetsDefaults) {
   EXPECT_TRUE(config.enforce_limit);
   EXPECT_EQ(config.default_limit, 1000);
   EXPECT_EQ(config.max_query_length, 4000);
+  EXPECT_FALSE(config.allow_system_tables);
   EXPECT_TRUE(config.show_explanation);
   EXPECT_TRUE(config.show_warnings);
   EXPECT_FALSE(config.show_suggested_visualization);

--- a/tests/unit/test_config.cpp
+++ b/tests/unit/test_config.cpp
@@ -228,8 +228,7 @@ api_key = sk-ant-test
 
   const auto* anthropic = ConfigManager::getProviderConfig(Provider::ANTHROPIC);
   ASSERT_NE(anthropic, nullptr);
-  EXPECT_EQ(anthropic->default_model,
-            DEFAULT_ANTHROPIC_MODEL);
+  EXPECT_EQ(anthropic->default_model, DEFAULT_ANTHROPIC_MODEL);
 }
 
 // Test numeric value parsing
@@ -310,8 +309,7 @@ TEST(ConfigurationTest, DefaultConstructorSetsDefaults) {
   EXPECT_FALSE(config.use_formatted_response);
 
   EXPECT_EQ(config.default_provider.provider, Provider::OPENAI);
-  EXPECT_EQ(config.default_provider.default_model,
-            DEFAULT_OPENAI_MODEL);
+  EXPECT_EQ(config.default_provider.default_model, DEFAULT_OPENAI_MODEL);
 }
 
 // Test ProviderConfig default constructor

--- a/tests/unit/test_query_parser.cpp
+++ b/tests/unit/test_query_parser.cpp
@@ -354,6 +354,20 @@ TEST_F(QueryParserTest, ParseResponse_SystemTableFixture) {
   EXPECT_THAT(result.error_message, testing::HasSubstr("system tables"));
 }
 
+TEST_F(QueryParserTest, ParseResponse_SystemTableAllowedWhenFlagTrue) {
+  std::string response = R"({
+        "sql": "SELECT * FROM information_schema.tables",
+        "explanation": "Lists all tables"
+    })";
+
+  QueryResult result =
+      QueryParser::parseQueryResponse(response, true /* allow_system_table_access */);
+
+  EXPECT_TRUE(result.success);
+  EXPECT_EQ(result.generated_query, "SELECT * FROM information_schema.tables");
+  EXPECT_EQ(result.explanation, "Lists all tables");
+}
+
 TEST_F(QueryParserTest, ParseResponse_MultipleWarningsFixture) {
   std::string response = readResponseFixture("multiple_warnings.json");
   ASSERT_FALSE(response.empty()) << "Could not read fixture file";

--- a/tests/unit/test_query_parser.cpp
+++ b/tests/unit/test_query_parser.cpp
@@ -360,8 +360,8 @@ TEST_F(QueryParserTest, ParseResponse_SystemTableAllowedWhenFlagTrue) {
         "explanation": "Lists all tables"
     })";
 
-  QueryResult result =
-      QueryParser::parseQueryResponse(response, true /* allow_system_table_access */);
+  QueryResult result = QueryParser::parseQueryResponse(
+      response, true /* allow_system_table_access */);
 
   EXPECT_TRUE(result.success);
   EXPECT_EQ(result.generated_query, "SELECT * FROM information_schema.tables");


### PR DESCRIPTION
## Summary

Fixes #39 (inadequate query instructions and get_table_details behavior for schema-qualified tables).

## Changes

### 1. Config option to allow system table queries
- Added **`allow_system_tables`** in the `[query]` section of `~/.pg_ai.config` (default: `false`).
- When `true`, the AI may generate queries that use `information_schema` or `pg_catalog` (e.g. for "show me the schema of table X").
- Prompt text and response parsing both respect this flag.

### 2. `get_table_details` schema-qualified name support
- Single-argument calls like `get_table_details('sample2.accounts')` are now supported.
- If the argument contains a dot and no second argument is passed, it is treated as `schema.table` and split so the correct schema and table are used.
- Fixes wrong `schema_name` (e.g. "public") and empty columns when using names like `sample2.accounts`.

### 3. Schema-aware table details in prompt building
- When building the prompt for `generate_query`, mentioned tables are matched by both bare name and schema-qualified name (e.g. `sample2.accounts`).
- Table details are fetched with the correct schema, so column info is included for the right table in multi-schema setups.

### 4. Tests and documentation
- New unit test for `parseQueryResponse(..., allow_system_table_access = true)`.
- Config tests updated for `allow_system_tables` default and parsing.
- Docs updated (config reference, configuration, api-reference) and SQL comment for `get_table_details` updated with schema-qualified usage.

## Configuration example

```ini
[query]
allow_system_tables = true
```

## Usage examples

```sql
-- Schema-qualified table (single argument)
SELECT get_table_details('sample2.accounts');

-- Allow queries like "show me the schema of my sample2.accounts table"
SELECT generate_query('show me the schema of my sample2.accounts table');
-- (requires allow_system_tables = true for information_schema-based answers)
```

## Testing

**Command:**
```bash
cd build && make pg_ai_query_tests && ./tests/pg_ai_query_tests
```

**Result:**
```
[==========] Running 102 tests from 9 test suites.
...
[  PASSED  ] 102 tests.
```

All tests pass, including:
- `ConfigManagerTest.ParsesBooleanValues` (parses `allow_system_tables = true`)
- `ConfigurationTest.DefaultConstructorSetsDefaults` (`allow_system_tables` defaults to `false`)
- `QueryParserTest.ParseResponse_SystemTableAccess` (system table rejected when flag is false)
- `QueryParserTest.ParseResponse_SystemTableAllowedWhenFlagTrue` (system table accepted when flag is true)
- `QueryParserTest.ParseResponse_SystemTableFixture` (fixture still rejects system table by default)
