### PR TITLE
Harden explain_query SQL validation

### DIFF
--- a/src/core/query_generator.cpp
+++ b/src/core/query_generator.cpp
@@ -521,6 +521,13 @@ ExplainResult QueryGenerator::explainQuery(const ExplainRequest& request) {
       return result;
     }
 
+    if (!utils::is_select_only_query(request.query_text)) {
+      result.error_message =
+          "Only SELECT queries can be explained. Mutating or DDL statements "
+          "(e.g. INSERT, UPDATE, DELETE, DROP) are not allowed for safety.";
+      return result;
+    }
+
     result.query = request.query_text;
 
     SPIConnection spi_conn;

--- a/src/core/query_generator.cpp
+++ b/src/core/query_generator.cpp
@@ -516,15 +516,9 @@ ExplainResult QueryGenerator::explainQuery(const ExplainRequest& request) {
   ExplainResult result{.success = false};
 
   try {
-    if (request.query_text.empty()) {
-      result.error_message = "Query text cannot be empty";
-      return result;
-    }
-
-    if (!utils::is_select_only_query(request.query_text)) {
-      result.error_message =
-          "Only SELECT queries can be explained. Mutating or DDL statements "
-          "(e.g. INSERT, UPDATE, DELETE, DROP) are not allowed for safety.";
+    if (auto validation_error =
+            utils::validate_sql_for_explain(request.query_text)) {
+      result.error_message = *validation_error;
       return result;
     }
 

--- a/src/include/utils.hpp
+++ b/src/include/utils.hpp
@@ -81,4 +81,16 @@ std::string read_file_or_throw(const std::string& filepath);
  */
 std::string formatAPIError(const std::string& raw_error);
 
+/**
+ * @brief Check if SQL is a read-only SELECT query for safe EXPLAIN
+ *
+ * Returns true only when the first keyword (after whitespace and comments)
+ * is SELECT. Rejects INSERT, UPDATE, DELETE, DROP, and other mutating or
+ * DDL statements to prevent execution via EXPLAIN ANALYZE.
+ *
+ * @param sql The SQL string to validate
+ * @return true if the query appears to be a SELECT-only statement
+ */
+bool is_select_only_query(const std::string& sql);
+
 }  // namespace pg_ai::utils

--- a/src/include/utils.hpp
+++ b/src/include/utils.hpp
@@ -93,4 +93,18 @@ std::string formatAPIError(const std::string& raw_error);
  */
 bool is_select_only_query(const std::string& sql);
 
+/**
+ * Validate SQL input for explain_query to prevent destructive queries.
+ *
+ * Examines the first SQL keyword after skipping leading whitespace and SQL
+ * comments (both line comments and block comments). Only SELECT and WITH
+ * (for CTE-based SELECTs) are allowed. All other statements (e.g. INSERT,
+ * UPDATE, DELETE, DROP, TRUNCATE, CREATE, ALTER) are rejected to avoid
+ * executing mutating or DDL statements via EXPLAIN ANALYZE.
+ *
+ * Returns std::nullopt if the SQL is safe to use with EXPLAIN, or an error
+ * message string if rejected.
+ */
+std::optional<std::string> validate_sql_for_explain(const std::string& sql);
+
 }  // namespace pg_ai::utils

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -116,7 +116,12 @@ std::string formatAPIError(const std::string& raw_error) {
   return raw_error;
 }
 
-bool is_select_only_query(const std::string& sql) {
+namespace {
+
+// Extract the first SQL keyword after skipping leading whitespace and
+// SQL comments (`--` line comments and `/* ... */` block comments).
+// Returns an empty string if no keyword is found.
+std::string extract_first_sql_keyword(const std::string& sql) {
   std::string s = sql;
   size_t i = 0;
   const size_t n = s.size();
@@ -162,7 +167,7 @@ bool is_select_only_query(const std::string& sql) {
   }
 
   if (i >= n) {
-    return false;
+    return {};
   }
 
   size_t start = i;
@@ -170,14 +175,41 @@ bool is_select_only_query(const std::string& sql) {
          (std::isalnum(static_cast<unsigned char>(s[i])) || s[i] == '_')) {
     ++i;
   }
-  std::string first_token = s.substr(start, i - start);
+
+  return s.substr(start, i - start);
+}
+
+}  // namespace
+
+bool is_select_only_query(const std::string& sql) {
+  std::string first_token = extract_first_sql_keyword(sql);
   if (first_token.empty()) {
     return false;
   }
-  for (char& c : first_token) {
-    c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
-  }
+
+  std::transform(first_token.begin(), first_token.end(), first_token.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
   return first_token == "select";
+}
+
+std::optional<std::string> validate_sql_for_explain(const std::string& sql) {
+  std::string first_token = extract_first_sql_keyword(sql);
+
+  if (first_token.empty()) {
+    return "Query text cannot be empty or contain only comments.";
+  }
+
+  std::transform(first_token.begin(), first_token.end(), first_token.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+
+  if (first_token == "SELECT" || first_token == "WITH") {
+    return std::nullopt;
+  }
+
+  return "Only SELECT and WITH (CTE) queries can be explained. Mutating or DDL "
+         "statements (e.g. INSERT, UPDATE, DELETE, DROP, TRUNCATE) are not "
+         "allowed for safety.";
 }
 
 }  // namespace pg_ai::utils

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -243,8 +243,9 @@ bool is_select_only_query(const std::string& sql) {
     return false;
   }
 
-  std::transform(first_token.begin(), first_token.end(), first_token.begin(),
-                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  std::transform(
+      first_token.begin(), first_token.end(), first_token.begin(),
+      [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
 
   return first_token == "select";
 }
@@ -256,8 +257,9 @@ std::optional<std::string> validate_sql_for_explain(const std::string& sql) {
     return "Query text cannot be empty or contain only comments.";
   }
 
-  std::transform(first_token.begin(), first_token.end(), first_token.begin(),
-                 [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+  std::transform(
+      first_token.begin(), first_token.end(), first_token.begin(),
+      [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
 
   if (first_token == "SELECT" || first_token == "WITH") {
     return std::nullopt;


### PR DESCRIPTION
## Summary

Restricts `explain_query` to safe read‑only SQL (first keyword `SELECT` or `WITH`) so that `EXPLAIN ANALYZE` cannot be used to execute mutating or DDL statements (e.g. DELETE, DROP, INSERT, UPDATE, TRUNCATE)

Fixes #103 

## Changes

- **`src/include/utils.hpp`**
  - Declare `bool is_select_only_query(const std::string& sql)`.
  - Declare `std::optional<std::string> validate_sql_for_explain(const std::string& sql)`.

- **`src/utils.cpp`**
  - Add internal helper to extract the first SQL keyword after skipping whitespace and both `--` and `/* ... */` comments.
  - Reimplement `is_select_only_query()` on top of this helper (true only for `SELECT`).
  - Implement `validate_sql_for_explain()`:
    - Allows `SELECT` and `WITH` (CTE) queries.
    - Rejects empty/comment‑only input and any other first keyword, returning a clear error message.

- **`src/core/query_generator.cpp`**
  - In `explainQuery()`, call `utils::validate_sql_for_explain(request.query_text)` up front.
  - If it returns an error, stop and do not run EXPLAIN

## Behavior

- **Allowed:** `SELECT ...`, `WITH ... SELECT ...` (with optional leading whitespace/comments)
- **Rejected:** INSERT, UPDATE, DELETE, DROP, TRUNCATE, CREATE, ALTER, and any non‑SELECT/WITH statement, or queries that are only whitespace/comments  
  Error message: *"Only SELECT and WITH (CTE) queries can be explained. Mutating or DDL statements (e.g. INSERT, UPDATE, DELETE, DROP, TRUNCATE) are not allowed for safety"*

## Testing

- Existing tests unchanged
- Manual verification: valid SELECT/WITH succeed; DELETE/DROP/TRUNCATE/etc. and comment‑only inputs return the new error without executing