### PR TITLE
Fix reserved pg_ schema prefix in test setup (#76)

### DIFF
--- a/tests/sql/setup.sql
+++ b/tests/sql/setup.sql
@@ -2,10 +2,10 @@
 -- This file sets up the test environment
 
 -- Create test schema
-CREATE SCHEMA IF NOT EXISTS pg_ai_test;
+CREATE SCHEMA IF NOT EXISTS ai_test;
 
 -- Create test tables for schema introspection tests
-CREATE TABLE IF NOT EXISTS pg_ai_test.users (
+CREATE TABLE IF NOT EXISTS ai_test.users (
     id SERIAL PRIMARY KEY,
     name VARCHAR(100) NOT NULL,
     email VARCHAR(255) UNIQUE NOT NULL,
@@ -13,15 +13,15 @@ CREATE TABLE IF NOT EXISTS pg_ai_test.users (
     active BOOLEAN DEFAULT true
 );
 
-CREATE TABLE IF NOT EXISTS pg_ai_test.orders (
+CREATE TABLE IF NOT EXISTS ai_test.orders (
     id SERIAL PRIMARY KEY,
-    user_id INTEGER REFERENCES pg_ai_test.users(id),
+    user_id INTEGER REFERENCES ai_test.users(id),
     total_amount DECIMAL(10, 2) NOT NULL,
     status VARCHAR(50) DEFAULT 'pending',
     order_date DATE DEFAULT CURRENT_DATE
 );
 
-CREATE TABLE IF NOT EXISTS pg_ai_test.products (
+CREATE TABLE IF NOT EXISTS ai_test.products (
     id SERIAL PRIMARY KEY,
     name VARCHAR(200) NOT NULL,
     price DECIMAL(10, 2) NOT NULL,
@@ -29,26 +29,26 @@ CREATE TABLE IF NOT EXISTS pg_ai_test.products (
     in_stock BOOLEAN DEFAULT true
 );
 
-CREATE TABLE IF NOT EXISTS pg_ai_test.order_items (
+CREATE TABLE IF NOT EXISTS ai_test.order_items (
     id SERIAL PRIMARY KEY,
-    order_id INTEGER REFERENCES pg_ai_test.orders(id),
-    product_id INTEGER REFERENCES pg_ai_test.products(id),
+    order_id INTEGER REFERENCES ai_test.orders(id),
+    product_id INTEGER REFERENCES ai_test.products(id),
     quantity INTEGER NOT NULL,
     unit_price DECIMAL(10, 2) NOT NULL
 );
 
 -- Create index for testing
-CREATE INDEX IF NOT EXISTS idx_users_email ON pg_ai_test.users(email);
-CREATE INDEX IF NOT EXISTS idx_orders_user_id ON pg_ai_test.orders(user_id);
+CREATE INDEX IF NOT EXISTS idx_users_email ON ai_test.users(email);
+CREATE INDEX IF NOT EXISTS idx_orders_user_id ON ai_test.orders(user_id);
 
 -- Insert some test data
-INSERT INTO pg_ai_test.users (name, email, active) VALUES
+INSERT INTO ai_test.users (name, email, active) VALUES
     ('Alice', 'alice@test.com', true),
     ('Bob', 'bob@test.com', true),
     ('Charlie', 'charlie@test.com', false)
 ON CONFLICT (email) DO NOTHING;
 
-INSERT INTO pg_ai_test.products (name, price, category, in_stock) VALUES
+INSERT INTO ai_test.products (name, price, category, in_stock) VALUES
     ('Widget', 9.99, 'gadgets', true),
     ('Gadget', 19.99, 'gadgets', true),
     ('Doohickey', 29.99, 'tools', false)

--- a/tests/sql/teardown.sql
+++ b/tests/sql/teardown.sql
@@ -2,13 +2,13 @@
 -- This file cleans up the test environment
 
 -- Drop test tables
-DROP TABLE IF EXISTS pg_ai_test.order_items CASCADE;
-DROP TABLE IF EXISTS pg_ai_test.orders CASCADE;
-DROP TABLE IF EXISTS pg_ai_test.products CASCADE;
-DROP TABLE IF EXISTS pg_ai_test.users CASCADE;
+DROP TABLE IF EXISTS ai_test.order_items CASCADE;
+DROP TABLE IF EXISTS ai_test.orders CASCADE;
+DROP TABLE IF EXISTS ai_test.products CASCADE;
+DROP TABLE IF EXISTS ai_test.users CASCADE;
 
 -- Drop test schema
-DROP SCHEMA IF EXISTS pg_ai_test CASCADE;
+DROP SCHEMA IF EXISTS ai_test CASCADE;
 
 -- Note: We don't drop the extension here as it might be used by other tests
 -- Use: DROP EXTENSION IF EXISTS pg_ai_query CASCADE; to remove the extension

--- a/tests/sql/test_extension_functions.sql
+++ b/tests/sql/test_extension_functions.sql
@@ -125,9 +125,9 @@ BEGIN
     -- First check if test table exists
     IF EXISTS (
         SELECT 1 FROM information_schema.tables
-        WHERE table_schema = 'pg_ai_test' AND table_name = 'users'
+        WHERE table_schema = 'ai_test' AND table_name = 'users'
     ) THEN
-        SELECT get_table_details('users', 'pg_ai_test') INTO result;
+        SELECT get_table_details('users', 'ai_test') INTO result;
 
         BEGIN
             json_result := result::jsonb;
@@ -142,7 +142,7 @@ BEGIN
             RAISE EXCEPTION 'FAIL: get_table_details returned invalid JSON: %', SQLERRM;
         END;
     ELSE
-        RAISE NOTICE 'SKIP: Test table pg_ai_test.users does not exist';
+        RAISE NOTICE 'SKIP: Test table ai_test.users does not exist';
     END IF;
 END $$;
 
@@ -154,9 +154,9 @@ DECLARE
 BEGIN
     IF EXISTS (
         SELECT 1 FROM information_schema.tables
-        WHERE table_schema = 'pg_ai_test' AND table_name = 'users'
+        WHERE table_schema = 'ai_test' AND table_name = 'users'
     ) THEN
-        SELECT get_table_details('users', 'pg_ai_test')::jsonb INTO result;
+        SELECT get_table_details('users', 'ai_test')::jsonb INTO result;
 
         SELECT jsonb_array_length(result->'columns') INTO column_count;
 
@@ -171,7 +171,7 @@ BEGIN
 
         RAISE NOTICE 'PASS: get_table_details returned % columns with proper structure', column_count;
     ELSE
-        RAISE NOTICE 'SKIP: Test table pg_ai_test.users does not exist';
+        RAISE NOTICE 'SKIP: Test table ai_test.users does not exist';
     END IF;
 END $$;
 

--- a/tests/test_helpers.hpp
+++ b/tests/test_helpers.hpp
@@ -35,7 +35,7 @@ class TempConfigFile {
  public:
   TempConfigFile(const std::string& content) {
     path_ = std::filesystem::temp_directory_path() /
-            ("pg_ai_test_config_" + std::to_string(rand()) + ".ini");
+            ("ai_test_config_" + std::to_string(rand()) + ".ini");
     std::ofstream file(path_);
     file << content;
   }


### PR DESCRIPTION
- Renamed test schema from `pg_ai_test` → `ai_test` across 4 files
- PostgreSQL reserves the `pg_` prefix for system schemas, so `CREATE SCHEMA pg_ai_test` always fails with:
    ERROR: unacceptable schema name "pg_ai_test"
    DETAIL: The prefix "pg_" is reserved for system schemas.
- CI silently suppressed this error (`2>/dev/null || true`), masking the fact that test data was never actually created


Fixes #76 