### PR TITLE
feat: env variables support using psqlrc

### DIFF
--- a/.psqlrc_pg_ai_query
+++ b/.psqlrc_pg_ai_query
@@ -1,0 +1,41 @@
+\set QUIET 1
+
+SELECT EXISTS (
+    SELECT 1
+    FROM pg_proc
+    WHERE proname = 'push_env_var'
+) AS has_push
+\gset
+
+\if :has_push
+    \set OPENAI_API_KEY `echo $OPENAI_API_KEY`
+    \set ANTHROPIC_API_KEY `echo $ANTHROPIC_API_KEY`
+    \set GEMINI_API_KEY `echo $GEMINI_API_KEY`
+
+    \pset tuples_only on
+
+    SELECT format(
+        'SELECT push_env_var(%L, %L);',
+        'OPENAI_API_KEY',
+        :'OPENAI_API_KEY'
+    )
+    \gexec
+
+    SELECT format(
+        'SELECT push_env_var(%L, %L);',
+        'ANTHROPIC_API_KEY',
+        :'ANTHROPIC_API_KEY'
+    )
+    \gexec
+
+    SELECT format(
+        'SELECT push_env_var(%L, %L);',
+        'GEMINI_API_KEY',
+        :'GEMINI_API_KEY'
+    )
+    \gexec
+
+    \pset tuples_only off
+\endif
+
+\set QUIET 0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.16)
 # Project definition
 # We use C++20 for features like designated initializers, std::format
 # and better template support which is required by modern AI SDKs.
-project(pg_ai_query 
+project(pg_ai_query
     VERSION 0.1.1
     LANGUAGES CXX
     DESCRIPTION "PostgreSQL extension for AI-powered query generation"
@@ -31,7 +31,7 @@ find_program(PG_CONFIG pg_config
 
 # If pg_config is not found, provide helpful installation instructions
 if(NOT PG_CONFIG)
-    message(FATAL_ERROR 
+    message(FATAL_ERROR
         "pg_config not found. Install postgresql-server-dev package.\n"
         "On Ubuntu: apt install postgresql-server-dev-14\n"
         "On Debian: apt install postgresql-server-dev-all\n"
@@ -118,7 +118,7 @@ if(APPLE)
     else()
         set(PG_EXTENSION_SUFFIX ".so")
     endif()
-    
+
     # Prefix must be empty (postgres expects 'pg_ai_query.so', not 'libpg_ai_query.so')
     # bundle_loader ensures symbols are resolved against the postgres binary at load time
     set_target_properties(pg_ai_query PROPERTIES
@@ -315,6 +315,13 @@ install(DIRECTORY prompts/
     DESTINATION ${PG_SHAREDIR}/extension/prompts/
     FILES_MATCHING PATTERN "*.txt"
 )
+
+# Define the path to your setup script
+set(SETUP_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/initalize_env_var_logic.sh")
+
+# Tell CMake to run this script during 'make install'
+install(CODE "execute_process(COMMAND bash ${SETUP_SCRIPT}
+              WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})")
 
 # Optional: Build logger test (not built by default)
 # Enable with: cmake .. -DBUILD_LOGGER_TEST=ON

--- a/initalize_env_var_logic.sh
+++ b/initalize_env_var_logic.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+REAL_USER=${SUDO_USER:-$USER}
+USER_HOME=$(getent passwd "$REAL_USER" | cut -d: -f6)
+
+if [ -z "$USER_HOME" ]; then
+    echo "Error: Could not determine home directory for $REAL_USER."
+    exit 1
+fi
+
+SOURCE_FILE=".psqlrc_pg_ai_query"
+TARGET_EXT_FILE="$USER_HOME/.psqlrc_pg_ai_query"
+MAIN_PSQLRC="$USER_HOME/.psqlrc"
+INCLUDE_LINE="\\i '$TARGET_EXT_FILE'"
+
+if [ -f "$SOURCE_FILE" ]; then
+    cp "$SOURCE_FILE" "$TARGET_EXT_FILE"
+
+    chown "$REAL_USER" "$TARGET_EXT_FILE"
+    chmod 600 "$TARGET_EXT_FILE"
+else
+    echo "Error: Source file $SOURCE_FILE not found in the current directory."
+    exit 1
+fi
+
+if [ ! -f "$MAIN_PSQLRC" ]; then
+    echo "  Creating new $MAIN_PSQLRC and adding include line."
+    echo -e "-- PostgreSQL Configuration\n$INCLUDE_LINE" > "$MAIN_PSQLRC"
+    chown "$REAL_USER" "$MAIN_PSQLRC"
+    chmod 600 "$MAIN_PSQLRC"
+elif grep -Fq "$TARGET_EXT_FILE" "$MAIN_PSQLRC"; then
+    echo "  Include line already exists in $MAIN_PSQLRC. Skipping."
+else
+    echo "  Appending include line to $MAIN_PSQLRC"
+    echo -e "\n$INCLUDE_LINE" >> "$MAIN_PSQLRC"
+fi
+
+echo "Successfully configured .psqlrc for $REAL_USER."

--- a/sql/pg_ai_query--1.0.sql
+++ b/sql/pg_ai_query--1.0.sql
@@ -88,3 +88,21 @@ Parameters:
 Returns: JSON with raw explain output and AI-generated performance insights
 Example: SELECT explain_query(''SELECT * FROM products ORDER BY price DESC LIMIT 10'', ''sk-...'', ''anthropic'');';
 
+
+CREATE TABLE IF NOT EXISTS client_env_vars (
+                                               var_name text PRIMARY KEY,
+                                               var_value text
+);
+
+CREATE OR REPLACE FUNCTION push_env_var(p_var_name text, p_var_value text)
+RETURNS void AS $$
+BEGIN
+    -- Only insert if the table exists
+    IF to_regclass('client_env_vars') IS NOT NULL THEN
+        INSERT INTO client_env_vars(var_name, var_value)
+        VALUES (p_var_name, p_var_value)
+        ON CONFLICT (var_name) DO UPDATE
+                                             SET var_value = EXCLUDED.var_value;
+END IF;
+END;
+$$ LANGUAGE plpgsql;

--- a/src/include/config.hpp
+++ b/src/include/config.hpp
@@ -179,6 +179,8 @@ class ConfigManager {
    * configuration file settings.
    */
   static void loadEnvConfig();
+
+  static char * readUserApiKeyEnvVariable(const std::string& provider);
 };
 
 // Convenience macros for accessing config

--- a/src/include/constants.hpp
+++ b/src/include/constants.hpp
@@ -39,4 +39,9 @@ constexpr int DEFAULT_ANTHROPIC_MAX_TOKENS = 8192;
 constexpr int DEFAULT_MAX_TOKENS = 4096;
 constexpr double DEFAULT_TEMPERATURE = 0.7;
 constexpr int DEFAULT_MAX_QUERY_LENGTH = 4000;
+
+// Env Variables Names
+constexpr const char* OPENAI_API_KEY_VARIABLE_NAME = "OPENAI_API_KEY";
+constexpr const char* ANTHROPIC_API_KEY_VARIABLE_NAME = "ANTHROPIC_API_KEY";
+constexpr const char* GEMINI_API_KEY_VARIABLE_NAME = "GEMINI_API_KEY";
 }  // namespace pg_ai::constants


### PR DESCRIPTION
closes #8 
i came across what is called "psqlrc" which runs startup scripts, i did use it to pick the env variables of the user shell session and push it in a kind of custom temp table that is generated on CREATE EXTENSION 
if you think this is the right approach i can continue working on it, there is some stuff that needs to be changed i guess 
@benodiwal 