### PR TITLE
refactor spi commands execution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ set(SOURCES
     src/utils.cpp
     src/prompts.cpp
     src/config.cpp
+    src/core/spi_command_executor.cpp
 )
 
 # Get PostgreSQL version to handle platform-specific naming conventions

--- a/src/core/spi_command_executor.cpp
+++ b/src/core/spi_command_executor.cpp
@@ -1,0 +1,45 @@
+#include "../include/spi_command_executor.hpp"
+
+namespace pg_ai {
+SPICommandExecutor::SPICommandExecutor() : tuptable(nullptr) {}
+
+SPICommandExecutor::~SPICommandExecutor() = default;
+
+std::pair<bool, std::string> SPICommandExecutor::execute(
+    const char* command,
+    bool isReadOnly,
+    long n_rows,
+    SPICommandType commandType,
+    const std::string& queryName) {
+  std::pair<bool, std::string> result = {false, ""};
+
+  if (!spi_connection) {
+    result.second = spi_connection.getErrorMessage();
+    return result;
+  }
+
+  int ret = SPI_execute(command, isReadOnly, n_rows);
+
+  if (ret < 0 || ret != commandTypeToSpiMacro(commandType)) {
+    result.second = "Failed to execute " + queryName +
+                    " query. SPI result code: " + std::to_string(ret) + " (" +
+                    std::string(SPI_result_code_string(ret)) + "). ";
+    return result;
+  }
+
+  if (SPI_processed == 0) {
+    result.second = "No output from" + queryName + " query";
+    return result;
+  }
+
+  result.first = true;
+  tuptable = SPI_tuptable;
+  return result;
+}
+
+SPIValue SPICommandExecutor::getCell(const int row, const int col) const {
+  TupleDesc tuple_desc = tuptable->tupdesc;
+  HeapTuple tuple = tuptable->vals[row];
+  return SPIValue(SPI_getvalue(tuple, tuple_desc, col));
+}
+}  // namespace pg_ai

--- a/src/include/spi_command_executor.hpp
+++ b/src/include/spi_command_executor.hpp
@@ -10,17 +10,16 @@ extern "C" {
 
 namespace pg_ai {
 
-enum class SPICommandType {
+enum class SPICommandType {  // lacks Merge and Merge returning for postgres
+                             // versions < 15
   OK_SELECT,
   OK_SELECT_INTO,
   OK_INSERT,
   OK_DELETE,
   OK_UPDATE,
-  OK_MERGE,
   OK_INSERT_RETURNING,
   OK_DELETE_RETURNING,
   OK_UPDATE_RETURNING,
-  OK_MERGE_RETURNING,
   OK_UTILITY,
   OK_REWRITTEN,
 };
@@ -55,8 +54,6 @@ class SPICommandExecutor {
         return SPI_OK_DELETE;
       case SPICommandType::OK_UPDATE:
         return SPI_OK_UPDATE;
-      case SPICommandType::OK_MERGE:
-        return SPI_OK_MERGE;
       case SPICommandType::OK_INSERT_RETURNING:
         return SPI_OK_INSERT_RETURNING;
       case SPICommandType::OK_DELETE_RETURNING:

--- a/src/include/spi_command_executor.hpp
+++ b/src/include/spi_command_executor.hpp
@@ -1,0 +1,81 @@
+#pragma once
+#include <string>
+
+#include "spi_connection.hpp"
+
+extern "C" {
+#include <postgres.h>
+#include <executor/spi.h>
+}
+
+namespace pg_ai {
+
+enum class SPICommandType {
+  OK_SELECT,
+  OK_SELECT_INTO,
+  OK_INSERT,
+  OK_DELETE,
+  OK_UPDATE,
+  OK_MERGE,
+  OK_INSERT_RETURNING,
+  OK_DELETE_RETURNING,
+  OK_UPDATE_RETURNING,
+  OK_MERGE_RETURNING,
+  OK_UTILITY,
+  OK_REWRITTEN,
+};
+
+class SPICommandExecutor {
+ public:
+  SPICommandExecutor();
+  ~SPICommandExecutor();
+
+  SPICommandExecutor(const SPICommandExecutor&) = delete;
+  SPICommandExecutor& operator=(const SPICommandExecutor&) = delete;
+  SPICommandExecutor(SPICommandExecutor&&) = delete;
+  SPICommandExecutor& operator=(SPICommandExecutor&&) = delete;
+
+  std::pair<bool, std::string> execute(const char* command,
+                                       bool isReadOnly,
+                                       long n_rows,
+                                       SPICommandType commandType,
+                                       const std::string& queryName);
+  SPIValue getCell(int row, int col) const;
+
+ private:
+  static int commandTypeToSpiMacro(SPICommandType command) {
+    switch (command) {
+      case SPICommandType::OK_SELECT:
+        return SPI_OK_SELECT;
+      case SPICommandType::OK_SELECT_INTO:
+        return SPI_OK_SELINTO;
+      case SPICommandType::OK_INSERT:
+        return SPI_OK_INSERT;
+      case SPICommandType::OK_DELETE:
+        return SPI_OK_DELETE;
+      case SPICommandType::OK_UPDATE:
+        return SPI_OK_UPDATE;
+      case SPICommandType::OK_MERGE:
+        return SPI_OK_MERGE;
+      case SPICommandType::OK_INSERT_RETURNING:
+        return SPI_OK_INSERT_RETURNING;
+      case SPICommandType::OK_DELETE_RETURNING:
+        return SPI_OK_DELETE_RETURNING;
+      case SPICommandType::OK_UPDATE_RETURNING:
+        return SPI_OK_UPDATE_RETURNING;
+      case SPICommandType::OK_UTILITY:
+        return SPI_OK_UTILITY;
+      case SPICommandType::OK_REWRITTEN:
+        return SPI_OK_REWRITTEN;
+      default:
+        return SPI_OK_SELECT;
+    }
+  }
+
+  SPIConnection
+      spi_connection;  // this has to exist as a member variable, so that its
+                       // destructor called on finishing of the executor
+  SPITupleTable* tuptable;
+};
+
+}  // namespace pg_ai

--- a/tests/unit/test_config.cpp
+++ b/tests/unit/test_config.cpp
@@ -228,8 +228,7 @@ api_key = sk-ant-test
 
   const auto* anthropic = ConfigManager::getProviderConfig(Provider::ANTHROPIC);
   ASSERT_NE(anthropic, nullptr);
-  EXPECT_EQ(anthropic->default_model,
-            DEFAULT_ANTHROPIC_MODEL);
+  EXPECT_EQ(anthropic->default_model, DEFAULT_ANTHROPIC_MODEL);
 }
 
 // Test numeric value parsing
@@ -307,8 +306,7 @@ TEST(ConfigurationTest, DefaultConstructorSetsDefaults) {
   EXPECT_FALSE(config.use_formatted_response);
 
   EXPECT_EQ(config.default_provider.provider, Provider::OPENAI);
-  EXPECT_EQ(config.default_provider.default_model,
-            DEFAULT_OPENAI_MODEL);
+  EXPECT_EQ(config.default_provider.default_model, DEFAULT_OPENAI_MODEL);
 }
 
 // Test ProviderConfig default constructor


### PR DESCRIPTION
what i made in a very short summary:
1- create a dedicated class for spi commands execution
2- removed some of the SPI_CONNECT and SPI_finish, which now are handled using the SPIConnection variable in the executor
3- used SPIValue instead which uses pfree in its destructor 


references i used (i was studying more about SPI):
https://www.postgresql.org/docs/current/spi.html
https://www.postgresql.org/docs/current/spi-spi-execute.html

i can add documentation to the new class if you think that this pr is worth it @benodiwal  