### PR TITLE
feat(config): add GUC variable support for API keys (pg_ai.openai_api_key, etc.)

### DIFF
--- a/src/include/config.hpp
+++ b/src/include/config.hpp
@@ -145,8 +145,33 @@ class ConfigManager {
    */
   static void reset();
 
+  /**
+   * @brief Apply GUC variable overrides on top of the file-parsed config.
+   *
+   * Called from PostgreSQL entry points (generate_query, explain_query) on
+   * every invocation, passing the current values of the pg_ai.* GUC vars.
+   *
+   * Internally rebuilds config_ from base_config_ (the file-parsed snapshot)
+   * before applying overrides, so RESET correctly reverts to the config file
+   * value rather than leaving a stale GUC value in place.
+   *
+   * A nullptr or empty string for any key means "no override for this
+   * provider — use whatever was in the config file."
+   *
+   * Safe to call in unit tests with literal const char* values; no PostgreSQL
+   * headers or GUC machinery are needed inside this method.
+   *
+   * @param openai_key    Value of pg_ai.openai_api_key GUC, or nullptr/""
+   * @param anthropic_key Value of pg_ai.anthropic_api_key GUC, or nullptr/""
+   * @param gemini_key    Value of pg_ai.gemini_api_key GUC, or nullptr/""
+   */
+  static void applyGucOverrides(const char* openai_key,
+                                 const char* anthropic_key,
+                                 const char* gemini_key);
+
  private:
   static Configuration config_;
+  static Configuration base_config_;
   static bool config_loaded_;
 
   /**


### PR DESCRIPTION
Resolves #8

Previous attempts at this issue:
- PR #98 used `std::getenv()` — fails because PostgreSQL workers don't 
  inherit the user's shell environment
- PR #111 uses `.psqlrc` — only works in interactive psql sessions, 
  not app connections

This implements GUC variables using PostgreSQL's native 
`DefineCustomStringVariable()`, which works for all connection methods.

**Usage:**
```sql
-- Per-session
SET pg_ai.openai_api_key = 'sk-...';
SET pg_ai.anthropic_api_key = 'sk-ant-...';
SET pg_ai.gemini_api_key = 'AIza...';
RESET pg_ai.openai_api_key;  -- reverts to config file value

-- Or persistently in postgresql.conf:
pg_ai.openai_api_key = 'sk-...'
```

Priority: SQL function parameter → GUC → config file → error

**Design notes:**
- `base_config_` snapshot taken after file parse so RESET correctly 
  reverts to config file value (not stale GUC value)
- `PGC_USERSET` — any user can SET their own key per-session
- `GUC_NO_SHOW_ALL` — keys hidden from SHOW ALL to avoid log leakage
- Fully backward compatible with `~/.pg_ai.config`

**Tests:** 7 new GUC tests added, 110 total, all pass.