### PR TITLE
docs: add field-level documentation to Configuration, QueryRequest, and related structs

### DIFF
--- a/src/include/config.hpp
+++ b/src/include/config.hpp
@@ -20,14 +20,32 @@ enum class Provider { OPENAI, ANTHROPIC, GEMINI, UNKNOWN };
  * including API keys, model selection, and endpoint configuration.
  */
 struct ProviderConfig {
+  /** AI provider type: OPENAI, ANTHROPIC, GEMINI, or UNKNOWN */
   Provider provider;
-  std::string api_key;
-  std::string default_model;
-  int default_max_tokens;
-  double default_temperature;
-  std::string api_endpoint;  // Custom API endpoint URL (optional)
 
-  // Default constructor
+  /** API key for authenticating with the provider (required) */
+  std::string api_key;
+
+  /**
+   * Model identifier to use for requests.
+   * Examples: "gpt-4o" (OpenAI), "claude-sonnet-4-5-20250929" (Anthropic),
+   *           "gemini-2.0-flash" (Gemini)
+   */
+  std::string default_model;
+
+  /** Maximum tokens in the AI response (default: 4096) */
+  int default_max_tokens;
+
+  /**
+   * Sampling temperature for response randomness (default: 0.7).
+   * Range: 0.0 (deterministic) to 2.0 (highly creative).
+   * Lower values produce more consistent SQL output.
+   */
+  double default_temperature;
+
+  /** Custom API endpoint URL. Leave empty to use the provider's default. */
+  std::string api_endpoint;
+
   ProviderConfig()
       : provider(Provider::UNKNOWN),
         default_max_tokens(4096),
@@ -43,28 +61,54 @@ struct ProviderConfig {
  * formatting preferences. Typically loaded from ~/.pg_ai.config.
  */
 struct Configuration {
+  /** The provider to use when none is specified in a request */
   ProviderConfig default_provider;
+
+  /** All configured providers (populated from config file sections) */
   std::vector<ProviderConfig> providers;
 
-  // General settings
+  // === General Settings ===
+
+  /** Log verbosity level: "DEBUG", "INFO", "WARNING", "ERROR" (default: "INFO") */
   std::string log_level;
+
+  /** Enable or disable all logging output (default: true) */
   bool enable_logging;
+
+  /** API request timeout in milliseconds (default: 30000 = 30 seconds) */
   int request_timeout_ms;
+
+  /** Maximum retry attempts for failed API requests; 0 disables retries (default: 3) */
   int max_retries;
 
-  // Query generation settings
+  // === Query Generation Settings ===
+
+  /**
+   * Automatically append a LIMIT clause to generated SELECT queries
+   * to prevent accidental large result sets (default: true)
+   */
   bool enforce_limit;
+
+  /** Row limit to apply when enforce_limit is true (default: 100) */
   int default_limit;
-  /** Maximum characters allowed in natural language query (default: 4000) */
+
+  /** Maximum characters allowed in the natural language input (default: 4000) */
   int max_query_length;
 
-  // Response format settings
+  // === Response Format Settings ===
+
+  /** Include a natural-language explanation of the generated SQL (default: true) */
   bool show_explanation;
+
+  /** Include warnings about potential issues with the generated query (default: true) */
   bool show_warnings;
+
+  /** Include a suggested visualization type for the query results (default: false) */
   bool show_suggested_visualization;
+
+  /** Return a structured JSON response instead of raw SQL text (default: true) */
   bool use_formatted_response;
 
-  // Default constructor with sensible defaults
   Configuration();
 };
 

--- a/src/include/query_generator.hpp
+++ b/src/include/query_generator.hpp
@@ -14,8 +14,13 @@ namespace pg_ai {
  * natural language using AI providers.
  */
 struct QueryRequest {
+  /** Natural language description of the desired query, e.g. "show all users older than 25" */
   std::string natural_language;
+
+  /** API key override; if empty, uses the key from the config file for the selected provider */
   std::string api_key;
+
+  /** Provider name override: "openai", "anthropic", or "gemini". Empty uses default_provider. */
   std::string provider;
 };
 
@@ -26,12 +31,25 @@ struct QueryRequest {
  * explanations, warnings, and success status.
  */
 struct QueryResult {
+  /** The generated SQL query string */
   std::string generated_query;
+
+  /** AI-generated explanation of what the query does (when show_explanation is true) */
   std::string explanation;
+
+  /** Potential issues or caveats about the generated query */
   std::vector<std::string> warnings;
+
+  /** Whether a LIMIT clause was automatically appended (when enforce_limit is true) */
   bool row_limit_applied;
+
+  /** Recommended chart/visualization type for the results, e.g. "bar", "table" */
   std::string suggested_visualization;
+
+  /** Whether query generation succeeded */
   bool success;
+
+  /** Error description when success is false */
   std::string error_message;
 };
 
@@ -97,8 +115,13 @@ struct DatabaseSchema {
  * Contains the SQL query to analyze and optional API configuration.
  */
 struct ExplainRequest {
+  /** The SQL query to analyze with EXPLAIN ANALYZE */
   std::string query_text;
+
+  /** API key override; if empty, uses the key from the config file for the selected provider */
   std::string api_key;
+
+  /** Provider name override: "openai", "anthropic", or "gemini". Empty uses default_provider. */
   std::string provider;
 };
 
@@ -109,10 +132,19 @@ struct ExplainRequest {
  * performance analysis with optimization suggestions.
  */
 struct ExplainResult {
+  /** The original SQL query that was analyzed */
   std::string query;
+
+  /** Raw PostgreSQL EXPLAIN (ANALYZE, VERBOSE, COSTS, BUFFERS, FORMAT JSON) output */
   std::string explain_output;
+
+  /** AI-generated performance analysis with optimization suggestions */
   std::string ai_explanation;
+
+  /** Whether the analysis completed successfully */
   bool success;
+
+  /** Error description when success is false */
   std::string error_message;
 };
 


### PR DESCRIPTION
Closes #43

## Summary

Added Doxygen-style documentation comments to all struct fields in:

**`src/include/config.hpp`:**
- `ProviderConfig`: provider, api_key, default_model, default_max_tokens, default_temperature, api_endpoint — with valid values and defaults
- `Configuration`: all 13 fields across general, query generation, and response format sections — with valid ranges and default values

**`src/include/query_generator.hpp`:**
- `QueryRequest`: natural_language, api_key, provider — with override behavior
- `QueryResult`: all 7 fields including row_limit_applied, suggested_visualization
- `ExplainRequest`: query_text, api_key, provider
- `ExplainResult`: all 5 fields including explain_output format details

## Test plan
- No functional changes; documentation only
- Verified files compile without warnings
