### PR TITLE
Add unit tests for documentation link handling in ResponseFormatter

### DIFF
--- a/tests/unit/test_response_formatter.cpp
+++ b/tests/unit/test_response_formatter.cpp
@@ -342,3 +342,52 @@ TEST_F(ResponseFormatterTest, JSONIsPrettyPrinted) {
   // Pretty-printed JSON should contain newlines
   EXPECT_THAT(output, testing::HasSubstr("\n"));
 }
+
+// Test that documentation links appear in formatted response
+
+TEST_F(ResponseFormatterTest, IncludesPostgresDocumentationLink) {
+  QueryResult result = createBasicResult();
+
+  result.explanation =
+      "PostgreSQL indexes improve query performance. "
+      "See https://www.postgresql.org/docs/current/indexes.html";
+
+  Configuration config = createConfig(false, true, false, false);
+
+  std::string formatted =
+      pg_ai::ResponseFormatter::formatResponse(result, config);
+
+  EXPECT_NE(formatted.find("postgresql.org/docs"), std::string::npos);
+}
+
+// Test specific documentation page
+TEST_F(ResponseFormatterTest, IndexDocumentationLinkPresent) {
+  QueryResult result = createBasicResult();
+
+  result.explanation =
+      "Documentation: https://www.postgresql.org/docs/current/indexes.html";
+
+  Configuration config = createConfig(false, true, false, false);
+
+  std::string formatted =
+      pg_ai::ResponseFormatter::formatResponse(result, config);
+
+  EXPECT_NE(formatted.find("indexes.html"), std::string::npos);
+}
+ // Test when no documentation link exists
+TEST_F(ResponseFormatterTest, HandlesMissingDocumentationLink) {
+  QueryResult result = createBasicResult();
+
+  result.explanation = "PostgreSQL indexes improve performance.";
+
+  Configuration config = createConfig(false, true, false, false);
+
+  std::string formatted =
+      pg_ai::ResponseFormatter::formatResponse(result, config);
+
+  EXPECT_EQ(formatted.find("postgresql.org/docs"), std::string::npos);
+}
+
+
+
+


### PR DESCRIPTION
## Summary
This PR adds unit tests to validate handling of PostgreSQL documentation links in `ResponseFormatter`.

## Changes
- Added tests to ensure documentation links are preserved in formatted responses
- Verified detection of PostgreSQL documentation URLs
- Added test cases for:
  - Presence of documentation links
  - Specific documentation pages (e.g., indexes.html)
  - Handling cases where no documentation links exist

## Testing
- All tests pass locally (108 tests)
- No regressions observed

## Notes
This change is test-only and does not modify production logic.