### PR TITLE
feat: schema-aware query generation with optional metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ set(SOURCES
     src/utils.cpp
     src/prompts.cpp
     src/config.cpp
+    src/core/metadata.cpp
 )
 
 # Get PostgreSQL version to handle platform-specific naming conventions

--- a/sql/pg_ai_query--1.0.sql
+++ b/sql/pg_ai_query--1.0.sql
@@ -13,12 +13,29 @@ RETURNS text
 AS 'MODULE_PATHNAME', 'generate_query'
 LANGUAGE C;
 
+-- Overload: Generate SQL using explicit user-provided schema context (JSON or text)
+CREATE OR REPLACE FUNCTION generate_query(
+    natural_language_query text,
+    api_key text,
+    provider text,
+    schema_context text
+)
+RETURNS text
+AS 'MODULE_PATHNAME', 'generate_query'
+LANGUAGE C;
+
 -- Example usage:
 -- SELECT generate_query('Show me all users created in the last 7 days');
 -- SELECT generate_query('Count orders by status');
 -- SELECT generate_query('Show me all users', 'your-api-key-here');
 -- SELECT generate_query('Show me all users', 'your-api-key-here', 'openai');
 -- SELECT generate_query('Show me all users', 'your-api-key-here', 'anthropic');
+-- SELECT generate_query(
+--   'show total order amount per customer',
+--   'your-api-key-here',
+--   'openai',
+--   '{"tables":[{"schema":"public","name":"orders","columns":["id","customer_id","amount"]},{"schema":"public","name":"customers","columns":["id","name"]}]}'
+-- );
 
 COMMENT ON FUNCTION generate_query(text, text, text) IS
 'Generate a PostgreSQL SELECT query from natural language description with automatic database schema discovery.
@@ -28,6 +45,16 @@ Parameters:
   - provider: AI provider name (openai, anthropic, gemini, or auto)
 Returns: Generated SQL query string
 Example: SELECT generate_query(''show top 10 products by sales'', ''sk-...'', ''openai'');';
+
+COMMENT ON FUNCTION generate_query(text, text, text, text) IS
+'Generate a PostgreSQL query from natural language using user-provided schema context.
+Parameters:
+    - natural_language_query: Natural language description of desired query
+    - api_key: API key for the AI provider (NULL to use config file)
+    - provider: AI provider name (openai, anthropic, gemini, or auto)
+    - schema_context: Schema details as JSON or plain text (tables and columns)
+Returns: Generated SQL query string or formatted response based on extension configuration
+Example: SELECT generate_query(''count orders by customer'', ''sk-...'', ''openai'', ''{"tables":[{"name":"orders","columns":["id","customer_id"]}]}'' );';
 
 -- Get all tables in the database with metadata
 CREATE OR REPLACE FUNCTION get_database_tables()

--- a/src/core/metadata.cpp
+++ b/src/core/metadata.cpp
@@ -1,0 +1,42 @@
+#include "metadata.hpp"
+
+using json = nlohmann::json;
+
+json extractSources(const std::string& text) {
+  json sources = json::array();
+
+  if (text.find("ST_") != std::string::npos) {
+    sources.push_back({
+        {"title", "PostGIS Documentation"},
+        {"url", "https://postgis.net/docs/"}});
+  }
+
+  if (text.find("SELECT") != std::string::npos) {
+    sources.push_back({
+        {"title", "PostgreSQL SELECT"},
+        {"url", "https://www.postgresql.org/docs/current/sql-select.html"}});
+  }
+
+  return sources;
+}
+
+double calculateConfidence(const std::string& text) {
+  if (text.length() > 150) return 0.9;
+  if (text.length() > 50) return 0.75;
+  return 0.6;
+}
+
+json extractTags(const std::string& text) {
+  json tags = json::array();
+
+  if (text.find("ST_") != std::string::npos)
+    tags.push_back("postgis");
+
+  if (text.find("JOIN") != std::string::npos)
+    tags.push_back("join");
+
+  if (text.find("INDEX") != std::string::npos)
+    tags.push_back("performance");
+
+  return tags;
+}

--- a/src/core/metadata.hpp
+++ b/src/core/metadata.hpp
@@ -1,0 +1,7 @@
+#pragma once
+#include <string>
+#include <nlohmann/json.hpp>
+
+nlohmann::json extractSources(const std::string& text);
+double calculateConfidence(const std::string& text);
+nlohmann::json extractTags(const std::string& text);

--- a/src/core/query_generator.cpp
+++ b/src/core/query_generator.cpp
@@ -166,30 +166,33 @@ std::string QueryGenerator::buildPrompt(const QueryRequest& request) {
   prompt << "Generate a PostgreSQL query for this request:\n\n";
   prompt << "Request: " << request.natural_language << "\n";
 
-  std::string schema_context;
-  try {
-    auto schema = getDatabaseTables();
-    if (schema.success) {
-      schema_context = formatSchemaForAI(schema);
+  std::string schema_context = normalizeSchemaContext(request.schema_context);
 
-      std::vector<std::string> mentioned_tables;
-      for (const auto& table : schema.tables) {
-        if (request.natural_language.find(table.table_name) !=
-            std::string::npos) {
-          mentioned_tables.push_back(table.table_name);
+  if (schema_context.empty()) {
+    try {
+      auto schema = getDatabaseTables();
+      if (schema.success) {
+        schema_context = formatSchemaForAI(schema);
+
+        std::vector<std::string> mentioned_tables;
+        for (const auto& table : schema.tables) {
+          if (request.natural_language.find(table.table_name) !=
+              std::string::npos) {
+            mentioned_tables.push_back(table.table_name);
+          }
+        }
+
+        for (size_t i = 0; i < mentioned_tables.size() && i < 3; ++i) {
+          auto table_details = getTableDetails(mentioned_tables[i]);
+          if (table_details.success) {
+            schema_context += "\n" + formatTableDetailsForAI(table_details);
+          }
         }
       }
-
-      for (size_t i = 0; i < mentioned_tables.size() && i < 3; ++i) {
-        auto table_details = getTableDetails(mentioned_tables[i]);
-        if (table_details.success) {
-          schema_context += "\n" + formatTableDetailsForAI(table_details);
-        }
-      }
+    } catch (const std::exception& e) {
+      logger::Logger::warning("Error building schema context for prompt: " +
+                              std::string(e.what()));
     }
-  } catch (const std::exception& e) {
-    logger::Logger::warning("Error building schema context for prompt: " +
-                            std::string(e.what()));
   }
 
   if (!schema_context.empty()) {
@@ -197,6 +200,97 @@ std::string QueryGenerator::buildPrompt(const QueryRequest& request) {
   }
 
   return prompt.str();
+}
+
+std::string QueryGenerator::normalizeSchemaContext(
+    const std::string& schema_context) {
+  if (schema_context.empty()) {
+    return "";
+  }
+
+  try {
+    nlohmann::json schema_json = nlohmann::json::parse(schema_context);
+    nlohmann::json tables_json;
+
+    if (schema_json.is_object() && schema_json.contains("tables") &&
+        schema_json["tables"].is_array()) {
+      tables_json = schema_json["tables"];
+    } else if (schema_json.is_array()) {
+      tables_json = schema_json;
+    }
+
+    if (!tables_json.is_array()) {
+      return schema_context;
+    }
+
+    std::ostringstream out;
+    out << "=== USER PROVIDED SCHEMA ===\n";
+    out << "Use this schema as source of truth for table/column names.\n\n";
+
+    for (const auto& table : tables_json) {
+      if (!table.is_object()) {
+        continue;
+      }
+
+      std::string table_name = table.value("table_name", "");
+      if (table_name.empty()) {
+        table_name = table.value("name", "");
+      }
+
+      std::string schema_name = table.value("schema_name", "");
+      if (schema_name.empty()) {
+        schema_name = table.value("schema", "");
+      }
+
+      if (table_name.empty()) {
+        continue;
+      }
+
+      if (!schema_name.empty()) {
+        out << "- " << schema_name << "." << table_name;
+      } else {
+        out << "- " << table_name;
+      }
+
+      if (table.contains("columns") && table["columns"].is_array()) {
+        std::vector<std::string> columns;
+        for (const auto& col : table["columns"]) {
+          if (col.is_string()) {
+            columns.push_back(col.get<std::string>());
+          } else if (col.is_object()) {
+            std::string col_name = col.value("column_name", "");
+            if (col_name.empty()) {
+              col_name = col.value("name", "");
+            }
+            if (!col_name.empty()) {
+              columns.push_back(col_name);
+            }
+          }
+        }
+
+        if (!columns.empty()) {
+          out << " columns: ";
+          for (size_t i = 0; i < columns.size(); ++i) {
+            if (i > 0) {
+              out << ", ";
+            }
+            out << columns[i];
+          }
+        }
+      }
+
+      out << "\n";
+    }
+
+    std::string normalized = out.str();
+    if (normalized.find("- ") == std::string::npos) {
+      return schema_context;
+    }
+
+    return normalized;
+  } catch (const std::exception&) {
+    return schema_context;
+  }
 }
 
 // Parsing logic has been moved to QueryParser class for testability

--- a/src/core/query_parser.cpp
+++ b/src/core/query_parser.cpp
@@ -143,6 +143,8 @@ QueryResult QueryParser::parseQueryResponse(const std::string& response_text) {
   nlohmann::json j = extractSQLFromResponse(response_text);
   std::string sql = j.value("sql", "");
   std::string explanation = j.value("explanation", "");
+  std::optional<double> confidence_score = std::nullopt;
+  nlohmann::json metadata = nlohmann::json::object();
 
   std::vector<std::string> warnings_vec;
   try {
@@ -168,6 +170,21 @@ QueryResult QueryParser::parseQueryResponse(const std::string& response_text) {
                             std::string(e.what()));
   }
 
+  try {
+    if (j.contains("confidence_score") &&
+        (j["confidence_score"].is_number_float() ||
+         j["confidence_score"].is_number_integer())) {
+      confidence_score = j["confidence_score"].get<double>();
+    }
+
+    if (j.contains("metadata") && j["metadata"].is_object()) {
+      metadata = j["metadata"];
+    }
+  } catch (const std::exception& e) {
+    logger::Logger::warning("Error parsing optional metadata fields: " +
+                            std::string(e.what()));
+  }
+
   // Check for error indicators in explanation/warnings
   if (hasErrorIndicators(explanation, warnings_vec)) {
     return QueryResult{.generated_query = "",
@@ -175,6 +192,8 @@ QueryResult QueryParser::parseQueryResponse(const std::string& response_text) {
                        .warnings = warnings_vec,
                        .row_limit_applied = false,
                        .suggested_visualization = "",
+                       .confidence_score = confidence_score,
+                       .metadata = metadata,
                        .success = false,
                        .error_message = explanation};
   }
@@ -186,6 +205,8 @@ QueryResult QueryParser::parseQueryResponse(const std::string& response_text) {
                        .warnings = warnings_vec,
                        .row_limit_applied = false,
                        .suggested_visualization = "",
+                       .confidence_score = confidence_score,
+                       .metadata = metadata,
                        .success = true,
                        .error_message = ""};
   }
@@ -211,6 +232,8 @@ QueryResult QueryParser::parseQueryResponse(const std::string& response_text) {
       .warnings = warnings_vec,
       .row_limit_applied = j.value("row_limit_applied", false),
       .suggested_visualization = j.value("suggested_visualization", "table"),
+      .confidence_score = confidence_score,
+      .metadata = metadata,
       .success = true,
       .error_message = ""};
 }

--- a/src/core/response_formatter.cpp
+++ b/src/core/response_formatter.cpp
@@ -3,6 +3,7 @@
 #include <sstream>
 #include <string>
 #include <nlohmann/json.hpp>
+#include "metadata.hpp"
 
 namespace pg_ai {
 namespace {
@@ -71,6 +72,13 @@ std::string ResponseFormatter::createJSONResponse(
   if (result.row_limit_applied) {
     response["row_limit_applied"] = true;
   }
+
+  // ✅ Add AI metadata (only if explanation exists)
+if (!result.explanation.empty()) {
+  response["sources"] = extractSources(result.explanation);
+  response["confidence"] = calculateConfidence(result.explanation);
+  response["tags"] = extractTags(result.explanation);
+}
 
   return response.dump(2);  // Pretty print with 2-space indentation
 }

--- a/src/core/response_formatter.cpp
+++ b/src/core/response_formatter.cpp
@@ -3,7 +3,6 @@
 #include <sstream>
 #include <string>
 #include <nlohmann/json.hpp>
-#include "metadata.hpp"
 
 namespace pg_ai {
 namespace {
@@ -73,12 +72,13 @@ std::string ResponseFormatter::createJSONResponse(
     response["row_limit_applied"] = true;
   }
 
-  // ✅ Add AI metadata (only if explanation exists)
-if (!result.explanation.empty()) {
-  response["sources"] = extractSources(result.explanation);
-  response["confidence"] = calculateConfidence(result.explanation);
-  response["tags"] = extractTags(result.explanation);
-}
+  if (result.confidence_score.has_value()) {
+    response["confidence_score"] = result.confidence_score.value();
+  }
+
+  if (result.metadata.is_object() && !result.metadata.empty()) {
+    response["metadata"] = result.metadata;
+  }
 
   return response.dump(2);  // Pretty print with 2-space indentation
 }

--- a/src/include/query_generator.hpp
+++ b/src/include/query_generator.hpp
@@ -2,6 +2,7 @@
 
 #include <optional>
 #include <string>
+#include <vector>
 
 #include <nlohmann/json.hpp>
 
@@ -17,6 +18,7 @@ struct QueryRequest {
   std::string natural_language;
   std::string api_key;
   std::string provider;
+  std::string schema_context;
 };
 
 /**
@@ -31,6 +33,8 @@ struct QueryResult {
   std::vector<std::string> warnings;
   bool row_limit_applied;
   std::string suggested_visualization;
+  std::optional<double> confidence_score;
+  nlohmann::json metadata;
   bool success;
   std::string error_message;
 };
@@ -244,6 +248,18 @@ class QueryGenerator {
    * @return Complete prompt string ready for AI API
    */
   static std::string buildPrompt(const QueryRequest& request);
+
+  /**
+   * @brief Normalize user-provided schema context for prompt inclusion
+   *
+   * Supports JSON and plain text formats. If JSON is provided in a
+   * recognized tables/columns shape, it is converted into concise
+   * table/column lines for the LLM prompt.
+   *
+   * @param schema_context Raw schema input from the user
+   * @return Normalized schema context string for prompt
+   */
+  static std::string normalizeSchemaContext(const std::string& schema_context);
 
   /**
    * @brief Log model configuration settings

--- a/src/pg_ai_query.cpp
+++ b/src/pg_ai_query.cpp
@@ -27,7 +27,7 @@ PG_FUNCTION_INFO_V1(explain_query);
 
 /**
  * generate_query(natural_language_query text, api_key text DEFAULT NULL,
- * provider text DEFAULT 'auto')
+ * provider text DEFAULT 'auto', schema_context text DEFAULT NULL)
  *
  * Generates a SQL query from natural language input with automatic schema
  * discovery Provider options: 'openai', 'anthropic', 'auto' (auto-select based
@@ -38,14 +38,20 @@ Datum generate_query(PG_FUNCTION_ARGS) {
     text* nl_query_arg = PG_GETARG_TEXT_PP(0);
     text* api_key_arg = PG_ARGISNULL(1) ? nullptr : PG_GETARG_TEXT_PP(1);
     text* provider_arg = PG_ARGISNULL(2) ? nullptr : PG_GETARG_TEXT_PP(2);
+  text* schema_context_arg =
+    (PG_NARGS() > 3 && !PG_ARGISNULL(3)) ? PG_GETARG_TEXT_PP(3) : nullptr;
 
     std::string nl_query = text_to_cstring(nl_query_arg);
     std::string api_key = api_key_arg ? text_to_cstring(api_key_arg) : "";
     std::string provider =
         provider_arg ? text_to_cstring(provider_arg) : "auto";
+  std::string schema_context =
+    schema_context_arg ? text_to_cstring(schema_context_arg) : "";
 
-    pg_ai::QueryRequest request{
-        .natural_language = nl_query, .api_key = api_key, .provider = provider};
+  pg_ai::QueryRequest request{.natural_language = nl_query,
+                .api_key = api_key,
+                .provider = provider,
+                .schema_context = schema_context};
 
     auto result = pg_ai::QueryGenerator::generateQuery(request);
 

--- a/src/prompts.cpp
+++ b/src/prompts.cpp
@@ -10,6 +10,7 @@ CRITICAL: You MUST generate the exact SQL operation the user requests - if they 
 ### INPUTS YOU WILL RECEIVE
 1. **User question** – natural language request.
 2. **Database schema** – available tables, columns, data types, constraints, relationships.
+  This may come from live database introspection or user-provided schema context.
 3. **Database dialect** – PostgreSQL.
 
 ### YOUR OUTPUT (JSON only, no extra text)
@@ -18,7 +19,9 @@ CRITICAL: You MUST generate the exact SQL operation the user requests - if they 
   "explanation": "plain English summary of what the query does",
   "warnings": ["list of risks, performance notes, or clarifications"] or [],
   "row_limit_applied": true/false,
-  "suggested_visualization": "bar|line|table|pie|none"
+  "suggested_visualization": "bar|line|table|pie|none",
+  "confidence_score": 0.0-1.0 (optional),
+  "metadata": {"key": "value"} (optional object)
 }
 
 ### VALIDATION RULES (CRITICAL)
@@ -85,6 +88,8 @@ All responses must be valid JSON with these fields:
 - warnings: array of warning strings
 - row_limit_applied: boolean
 - suggested_visualization: string
+- confidence_score: optional float between 0 and 1
+- metadata: optional object for additional structured context
 )";
 
 const std::string EXPLAIN_SYSTEM_PROMPT =

--- a/tests/unit/test_metadata.cpp
+++ b/tests/unit/test_metadata.cpp
@@ -1,0 +1,17 @@
+#include <cassert>
+#include "/home/lucifer/Desktop/pg_ai_query/src/core/metadata.hpp"
+
+int main() {
+    std::string text = "Use ST_Distance in PostGIS";
+
+    auto sources = extractSources(text);
+    assert(!sources.empty());
+
+    double conf = calculateConfidence(text);
+    assert(conf > 0);
+
+    auto tags = extractTags(text);
+    assert(!tags.empty());
+
+    return 0;
+}

--- a/tests/unit/test_query_parser.cpp
+++ b/tests/unit/test_query_parser.cpp
@@ -310,6 +310,27 @@ TEST_F(QueryParserTest, ParseResponse_DefaultVisualization) {
   EXPECT_EQ(result.suggested_visualization, "table");
 }
 
+TEST_F(QueryParserTest, ParseResponse_WithConfidenceAndMetadata) {
+  std::string response = R"({
+        "sql": "SELECT id, email FROM users",
+        "explanation": "Retrieves user identifiers and emails",
+        "confidence_score": 0.87,
+        "metadata": {
+          "intent": "reporting",
+          "tables_used": ["users"]
+        }
+    })";
+
+  QueryResult result = QueryParser::parseQueryResponse(response);
+
+  EXPECT_TRUE(result.success);
+  ASSERT_TRUE(result.confidence_score.has_value());
+  EXPECT_DOUBLE_EQ(result.confidence_score.value(), 0.87);
+  ASSERT_TRUE(result.metadata.is_object());
+  EXPECT_EQ(result.metadata["intent"], "reporting");
+  EXPECT_EQ(result.metadata["tables_used"].size(), 1);
+}
+
 // Test with fixture files
 TEST_F(QueryParserTest, ParseResponse_ValidQueryFixture) {
   std::string response = readResponseFixture("valid_query_response.json");

--- a/tests/unit/test_response_formatter.cpp
+++ b/tests/unit/test_response_formatter.cpp
@@ -342,3 +342,52 @@ TEST_F(ResponseFormatterTest, JSONIsPrettyPrinted) {
   // Pretty-printed JSON should contain newlines
   EXPECT_THAT(output, testing::HasSubstr("\n"));
 }
+
+// Test that documentation links appear in formatted response
+
+TEST_F(ResponseFormatterTest, IncludesPostgresDocumentationLink) {
+  QueryResult result = createBasicResult();
+
+  result.explanation =
+      "PostgreSQL indexes improve query performance. "
+      "See https://www.postgresql.org/docs/current/indexes.html";
+
+  Configuration config = createConfig(false, true, false, false);
+
+  std::string formatted =
+      pg_ai::ResponseFormatter::formatResponse(result, config);
+
+  EXPECT_NE(formatted.find("postgresql.org/docs"), std::string::npos);
+}
+
+// Test specific documentation page
+TEST_F(ResponseFormatterTest, IndexDocumentationLinkPresent) {
+  QueryResult result = createBasicResult();
+
+  result.explanation =
+      "Documentation: https://www.postgresql.org/docs/current/indexes.html";
+
+  Configuration config = createConfig(false, true, false, false);
+
+  std::string formatted =
+      pg_ai::ResponseFormatter::formatResponse(result, config);
+
+  EXPECT_NE(formatted.find("indexes.html"), std::string::npos);
+}
+ // Test when no documentation link exists
+TEST_F(ResponseFormatterTest, HandlesMissingDocumentationLink) {
+  QueryResult result = createBasicResult();
+
+  result.explanation = "PostgreSQL indexes improve performance.";
+
+  Configuration config = createConfig(false, true, false, false);
+
+  std::string formatted =
+      pg_ai::ResponseFormatter::formatResponse(result, config);
+
+  EXPECT_EQ(formatted.find("postgresql.org/docs"), std::string::npos);
+}
+
+
+
+

--- a/tests/unit/test_response_formatter.cpp
+++ b/tests/unit/test_response_formatter.cpp
@@ -319,6 +319,21 @@ TEST_F(ResponseFormatterTest, EmptyWarningsNotIncluded) {
   EXPECT_FALSE(j.contains("warnings"));
 }
 
+TEST_F(ResponseFormatterTest, JSONIncludesConfidenceAndMetadata) {
+  auto result = createBasicResult();
+  result.confidence_score = 0.92;
+  result.metadata = json{{"intent", "analytics"}, {"tables_used", {"users"}}};
+  auto config = createConfig(true, true, false, false);
+
+  std::string output = ResponseFormatter::formatResponse(result, config);
+  json j = json::parse(output);
+
+  ASSERT_TRUE(j.contains("confidence_score"));
+  EXPECT_DOUBLE_EQ(j["confidence_score"].get<double>(), 0.92);
+  ASSERT_TRUE(j.contains("metadata"));
+  EXPECT_EQ(j["metadata"]["intent"], "analytics");
+}
+
 // Test empty visualization is not included
 TEST_F(ResponseFormatterTest, EmptyVisualizationNotIncluded) {
   auto result = createBasicResult();


### PR DESCRIPTION
Summary:
Added schema-aware query generation so callers can pass explicit schema context (tables/columns) with natural-language requests, and extended structured output with optional confidence and metadata.

Changes:
Added schema_context to query request handling.
Updated prompt build flow to prefer user-provided schema context.
Added normalization of supported JSON schema formats into LLM-friendly prompt text.
Kept existing live DB schema introspection as fallback when schema_context is absent.
Extended parser to accept optional confidence_score and metadata from model JSON.
Extended JSON response formatting to include confidence_score and metadata when present.
Added SQL overload for generate_query with a 4th schema_context parameter.
Updated system prompt output contract to document confidence_score and metadata.
Added unit test coverage for parser and formatter metadata/confidence behavior.

Validation:
cmake -S . -B build
cmake --build build -j

Notes:
Behavior remains backward-compatible when schema_context is not provided.
Optional fields are omitted when absent.


Fixes:#141